### PR TITLE
Improve Python JSON assertions, timeout for tests

### DIFF
--- a/core/src/main/kotlin/org/evomaster/core/output/service/ApiTestCaseWriter.kt
+++ b/core/src/main/kotlin/org/evomaster/core/output/service/ApiTestCaseWriter.kt
@@ -100,7 +100,7 @@ abstract class ApiTestCaseWriter : TestCaseWriter() {
                 val list = Gson().fromJson(bodyString, List::class.java)
                 handleAssertionsOnList(list, lines, "", bodyVarName)
                 } catch (e: JsonSyntaxException) {
-                    lines.add("/* Failed to parse JSON response */")
+                    lines.addSingleCommentLine("Failed to parse JSON response")
                 }
             }
             '{' -> {
@@ -109,7 +109,7 @@ abstract class ApiTestCaseWriter : TestCaseWriter() {
                     val resContents = Gson().fromJson(bodyString, Map::class.java)
                     handleAssertionsOnObject(resContents as Map<String, *>, lines, "", bodyVarName)
                 } catch (e: JsonSyntaxException) {
-                    lines.add("/* Failed to parse JSON response */")
+                    lines.addSingleCommentLine("Failed to parse JSON response")
                 }
             }
             '"' -> {
@@ -124,7 +124,7 @@ abstract class ApiTestCaseWriter : TestCaseWriter() {
                     it does not the seem the case for Jest/SuperAgent
                  */
                 when {
-                    isTooLargeBody -> lines.add("/* very large body, which was not handled during the search */")
+                    isTooLargeBody -> lines.addSingleCommentLine("very large body, which was not handled during the search")
 
                     bodyString.isNullOrBlank() -> lines.add(emptyBodyCheck(bodyVarName))
 
@@ -143,7 +143,7 @@ abstract class ApiTestCaseWriter : TestCaseWriter() {
             format.isJavaOrKotlin() -> {
                 lines.add(bodyIsString(s, GeneUtils.EscapeMode.BODY, responseVariableName))
             }
-            format.isJavaScript() || format.isCsharp() -> {
+            format.isJavaScript() || format.isCsharp() || format.isPython() -> {
                 try {
                     val number = s.toDouble()
                     handleAssertionsOnField(number, lines, fieldPath, responseVariableName)
@@ -174,6 +174,7 @@ abstract class ApiTestCaseWriter : TestCaseWriter() {
                 format.isJavaOrKotlin() -> if (fieldPath.isEmpty()) "" else if (fieldPath.startsWith("'")) "$fieldPath." else "'$fieldPath'."
                 format.isJavaScript() -> if (fieldPath.isEmpty()) "" else "${if (fieldPath.startsWith("[") || fieldPath.startsWith(".")) "" else "."}$fieldPath"
                 format.isCsharp() -> if (fieldPath.isEmpty()) "" else "${if (fieldPath.startsWith("[")) "" else "."}$fieldPath"
+                format.isPython() -> if (fieldPath.isEmpty()) "" else "${if (fieldPath.startsWith("[") || fieldPath.startsWith(".")) "" else "."}$fieldPath"
                 else -> throw IllegalStateException("Format not supported yet: $format")
             }
 
@@ -183,6 +184,7 @@ abstract class ApiTestCaseWriter : TestCaseWriter() {
                 format.isKotlin() -> ".body(\"${k}isEmpty()\", `is`(true))" //'is' is a keyword in Kotlin
                 format.isJavaScript() -> "expect(Object.keys($responseVariableName.body${k}).length).toBe(0);"
                 format.isCsharp() -> "Assert.True($responseVariableName${k}.ToString() == \"{}\");"
+                format.isPython() -> "assert len($responseVariableName.json()${k}) == 0"
                 else -> throw IllegalStateException("Format not supported yet: $format")
             }
 
@@ -207,6 +209,9 @@ abstract class ApiTestCaseWriter : TestCaseWriter() {
                             needsDot = false
                             "[\"${it.key}\"]"
                         }
+                    } else if (format.isPython()) {
+                        needsDot = false
+                        "[\"${it.key}\"]"
                     //TODO need to deal with '' C#? see EscapeRest
                     } else {
                         it.key
@@ -239,6 +244,7 @@ abstract class ApiTestCaseWriter : TestCaseWriter() {
                 format.isJavaOrKotlin() -> ".body(\"${fieldPath}\", nullValue())"
                 format.isJavaScript() -> "expect($responseVariableName.body$fieldPath).toBe(null);"
                 format.isCsharp() -> "Assert.True($responseVariableName$fieldPath == null);"
+                format.isPython() -> "assert $responseVariableName.json()$fieldPath is None"
                 else -> throw IllegalStateException("Format not supported yet: $format")
             }
             lines.add(instruction)
@@ -271,7 +277,7 @@ abstract class ApiTestCaseWriter : TestCaseWriter() {
             return
         }
 
-        if (format.isJavaScript() || format.isCsharp()) {
+        if (format.isJavaScript() || format.isCsharp() || format.isPython()) {
             val toPrint = if (value is String) {
                 "\"" + GeneUtils.applyEscapes(value, mode = GeneUtils.EscapeMode.ASSERTION, format = format) + "\""
             } else {
@@ -281,6 +287,8 @@ abstract class ApiTestCaseWriter : TestCaseWriter() {
             if (isSuitableToPrint(toPrint)) {
                 if (format.isJavaScript()) {
                     lines.add("expect($responseVariableName.body$fieldPath).toBe($toPrint);")
+                } else if (format.isPython()){
+                    lines.add("assert $responseVariableName.json()$fieldPath == $toPrint")
                 } else {
                     assert(format.isCsharp())
                     if (fieldPath != ".traceId" || !lines.toString().contains("status == 400"))
@@ -331,7 +339,7 @@ abstract class ApiTestCaseWriter : TestCaseWriter() {
             handleAssertionsOnField(list[i], lines, "$fieldPath[$i]", responseVariableName)
         }
         if (skipped > 0) {
-            lines.add("// Skipping assertions on the remaining $skipped elements. This limit of $limit elements can be increased in the configurations")
+            lines.addSingleCommentLine("Skipping assertions on the remaining $skipped elements. This limit of $limit elements can be increased in the configurations")
         }
     }
 
@@ -359,6 +367,10 @@ abstract class ApiTestCaseWriter : TestCaseWriter() {
             return "Assert.True(string.IsNullOrEmpty(await $responseVariableName.Content.ReadAsStringAsync()));"
         }
 
+        if (format.isPython()) {
+            return "assert $responseVariableName.text == ''"
+        }
+
         throw IllegalStateException("Unsupported format $format")
     }
 
@@ -377,6 +389,8 @@ abstract class ApiTestCaseWriter : TestCaseWriter() {
                 "expect($responseVariableName.body$fieldPath.length).toBe($expectedSize);"
             format.isCsharp() ->
                 "Assert.True($responseVariableName$fieldPath.Count == $expectedSize);"
+            format.isPython() ->
+                "assert len($responseVariableName.json()$fieldPath) == $expectedSize"
             else -> throw IllegalStateException("Not supported format $format")
         }
 
@@ -402,6 +416,10 @@ abstract class ApiTestCaseWriter : TestCaseWriter() {
                 else -> content
             }
             return "Assert.True($responseVariableName == \"$k\");"
+        }
+
+        if (format.isPython()) {
+            return "assert \"$content\" in $responseVariableName.text"
         }
 
         throw IllegalStateException("Not supported format $format")

--- a/core/src/main/kotlin/org/evomaster/core/output/service/TestCaseWriter.kt
+++ b/core/src/main/kotlin/org/evomaster/core/output/service/TestCaseWriter.kt
@@ -85,6 +85,10 @@ abstract class TestCaseWriter {
             }
         }
 
+        if (format.isPython() && config.testTimeout > 0) {
+            lines.add("@timeout_decorator.timeout(${config.testTimeout})")
+        }
+
         //TODO: check xUnit instead
         if (format.isCsharp()) {
             lines.add("[Fact]")

--- a/core/src/main/kotlin/org/evomaster/core/output/service/TestSuiteWriter.kt
+++ b/core/src/main/kotlin/org/evomaster/core/output/service/TestSuiteWriter.kt
@@ -476,6 +476,9 @@ class TestSuiteWriter {
             lines.add("import json")
             lines.add("import unittest")
             lines.add("import requests")
+            if (config.testTimeout > 0) {
+                lines.add("import timeout_decorator")
+            }
         }
 
         when {

--- a/core/src/test/kotlin/org/evomaster/core/output/PythonTestCaseWriterTest.kt
+++ b/core/src/test/kotlin/org/evomaster/core/output/PythonTestCaseWriterTest.kt
@@ -178,7 +178,18 @@ class PythonTestCaseWriterTest {
                             headers=headers)
                 
                 assert res_0.status_code == 200
-                assert res_0.json() == json.loads("[\n     {},\n     {\n         \"id\":\"foo\",\n         \"properties\":[\n             {},\n             {\n               \"name\":\"mapProperty1\",\n               \"type\":\"string\",\n               \"value\":\"one\"\n             },\n             {\n               \"name\":\"mapProperty2\",\n               \"type\":\"string\",\n               \"value\":\"two\"\n             }],\n         \"empty\":{}\n     }\n]")
+                assert "application/json" in res_0.headers["content-type"]
+                assert len(res_0.json()) == 2
+                assert len(res_0.json()[0]) == 0
+                assert len(res_0.json()[1]["properties"]) == 3
+                assert len(res_0.json()[1]["properties"][0]) == 0
+                assert res_0.json()[1]["properties"][1]["name"] == "mapProperty1"
+                assert res_0.json()[1]["properties"][1]["type"] == "string"
+                assert res_0.json()[1]["properties"][1]["value"] == "one"
+                assert res_0.json()[1]["properties"][2]["name"] == "mapProperty2"
+                assert res_0.json()[1]["properties"][2]["type"] == "string"
+                assert res_0.json()[1]["properties"][2]["value"] == "two"
+                assert len(res_0.json()[1]["empty"]) == 0
 
 """.trimIndent()
 
@@ -241,7 +252,17 @@ class PythonTestCaseWriterTest {
                             headers=headers)
                 
                 assert res_0.status_code == 200
-                assert res_0.json() == json.loads("{\n     \"p1\":{},\n     \"p2\":{\n         \"id\":\"foo\",\n         \"properties\":[\n             {},\n             {\n               \"name\":\"mapProperty1\",\n               \"type\":\"string\",\n               \"value\":\"one\"\n             },\n             {\n               \"name\":\"mapProperty2\",\n               \"type\":\"string\",\n               \"value\":\"two\"\n             }],\n         \"empty\":{}\n     }\n}")
+                assert "application/json" in res_0.headers["content-type"]
+                assert len(res_0.json()["p1"]) == 0
+                assert len(res_0.json()["p2"]["properties"]) == 3
+                assert len(res_0.json()["p2"]["properties"][0]) == 0
+                assert res_0.json()["p2"]["properties"][1]["name"] == "mapProperty1"
+                assert res_0.json()["p2"]["properties"][1]["type"] == "string"
+                assert res_0.json()["p2"]["properties"][1]["value"] == "one"
+                assert res_0.json()["p2"]["properties"][2]["name"] == "mapProperty2"
+                assert res_0.json()["p2"]["properties"][2]["type"] == "string"
+                assert res_0.json()["p2"]["properties"][2]["value"] == "two"
+                assert len(res_0.json()["p2"]["empty"]) == 0
 
 """.trimIndent()
         assertEquals(expectedLines, lines.toString())
@@ -290,7 +311,8 @@ class PythonTestCaseWriterTest {
                             headers=headers)
                 
                 assert res_0.status_code == 200
-                assert res_0.json() == json.loads("{\n     \"email\":\"foo@foo.foo\"\n}")
+                assert "application/json" in res_0.headers["content-type"]
+                assert res_0.json()["email"] == "foo@foo.foo"
 
 """.trimIndent()
         assertEquals(expectedLines, lines.toString())


### PR DESCRIPTION
# What
- Assertion over JSON without having to compare against the raw string
- Timeout for python tests