### PR TITLE
Feat/solver table alias

### DIFF
--- a/core/src/main/kotlin/org/evomaster/core/solver/SMTConditionVisitor.kt
+++ b/core/src/main/kotlin/org/evomaster/core/solver/SMTConditionVisitor.kt
@@ -6,6 +6,12 @@ import org.evomaster.solver.smtlib.SMTNode
 import org.evomaster.solver.smtlib.assertion.*
 import java.util.*
 
+/**
+ * Visitor to convert SQL conditions to SMT nodes
+ * @param defaultTableName table Name corresponding to the condition (this is used when only one table is involved)
+ * @param tableAliases the table aliases used in the query, so then we can know which table is being referred to
+ * @param rowIndex the row index to be used when declaring the variables in SMTlib
+ * */
 class SMTConditionVisitor(
     private val defaultTableName: String,
     private val tableAliases: Map<String, String>,

--- a/core/src/main/kotlin/org/evomaster/core/solver/SmtLibGenerator.kt
+++ b/core/src/main/kotlin/org/evomaster/core/solver/SmtLibGenerator.kt
@@ -1,5 +1,6 @@
 package org.evomaster.core.solver
 
+import net.sf.jsqlparser.expression.Expression
 import net.sf.jsqlparser.statement.Statement
 import net.sf.jsqlparser.statement.select.PlainSelect
 import net.sf.jsqlparser.statement.select.Select
@@ -84,7 +85,7 @@ class SmtLibGenerator(private val schema: DbSchemaDto, private val numberOfRows:
     }
 
     private fun parseCheckExpression(table: TableDto, condition: SqlCondition, index: Int): SMTNode {
-        val visitor = SMTConditionVisitor(table.name.lowercase(Locale.getDefault()), index)
+        val visitor = SMTConditionVisitor(table.name.lowercase(Locale.getDefault()), emptyMap<String, String>(), index)
         return condition.accept(visitor, null) as SMTNode
     }
 
@@ -193,20 +194,47 @@ class SmtLibGenerator(private val schema: DbSchemaDto, private val numberOfRows:
     }
 
     private fun appendQueryConstraints(smt: SMTLib, sqlQuery: Statement) {
+        val tableAliases = extractTableAliases(sqlQuery)
+
         if (sqlQuery is Select) { // TODO: Handle other queries
             val plainSelect = sqlQuery.selectBody as PlainSelect
             val where = plainSelect.where
-            val tableFromQuery = TablesNamesFinder().getTables(sqlQuery as Statement).firstOrNull();
-            val tableFromQueryDto = schema.tables.first { it.name.equals(tableFromQuery, ignoreCase = true) } // todo: Handle error case
 
             if (where != null) {
                 val condition = parser.parse(where.toString(), toDBType(schema.databaseType))
+                val tableFromQuery = TablesNamesFinder().getTables(sqlQuery as Statement).first();
                 for (i in 1..numberOfRows) {
-                    val constraint = parseCheckExpression(tableFromQueryDto, condition, i)
+                    val constraint = parseQueryCondition(tableAliases, tableFromQuery, condition, i)
                     smt.addNode(constraint)
                 }
             }
         }
+    }
+
+    private fun parseQueryCondition(tableAliases: Map<String, String>, defaultTableName: String, condition: SqlCondition, index: Int): SMTNode {
+        val visitor = SMTConditionVisitor(defaultTableName, tableAliases, index)
+        return condition.accept(visitor, null) as SMTNode
+    }
+
+    private fun extractTableAliases(sqlQuery: Statement): Map<String, String> {
+        val tableAliasMap = mutableMapOf<String, String>()
+        if (sqlQuery is Select) { // TODO: Handle other queries
+            val plainSelect = sqlQuery.selectBody as PlainSelect
+            val fromItem = plainSelect.fromItem
+            val tableName = (fromItem as net.sf.jsqlparser.schema.Table).name
+            val alias = fromItem.alias?.name ?: tableName
+            tableAliasMap[alias] = tableName
+
+            val joins = plainSelect.joins
+            if (joins != null) {
+                for (join in joins) {
+                    val joinAlias = join.rightItem.alias?.name ?: join.rightItem.toString()
+                    val joinName = (join.rightItem as net.sf.jsqlparser.schema.Table).name
+                    tableAliasMap[joinAlias] = joinName
+                }
+            }
+        }
+        return tableAliasMap
     }
 
     private fun appendGetValues(smt: SMTLib) {

--- a/core/src/main/kotlin/org/evomaster/core/solver/SmtLibGenerator.kt
+++ b/core/src/main/kotlin/org/evomaster/core/solver/SmtLibGenerator.kt
@@ -1,6 +1,5 @@
 package org.evomaster.core.solver
 
-import net.sf.jsqlparser.expression.Expression
 import net.sf.jsqlparser.statement.Statement
 import net.sf.jsqlparser.statement.select.PlainSelect
 import net.sf.jsqlparser.statement.select.Select

--- a/core/src/main/kotlin/org/evomaster/core/solver/SmtLibGenerator.kt
+++ b/core/src/main/kotlin/org/evomaster/core/solver/SmtLibGenerator.kt
@@ -84,7 +84,7 @@ class SmtLibGenerator(private val schema: DbSchemaDto, private val numberOfRows:
     }
 
     private fun parseCheckExpression(table: TableDto, condition: SqlCondition, index: Int): SMTNode {
-        val visitor = SMTConditionVisitor(table.name.lowercase(Locale.getDefault()), emptyMap<String, String>(), index)
+        val visitor = SMTConditionVisitor(table.name.lowercase(Locale.getDefault()), emptyMap(), schema.tables, index)
         return condition.accept(visitor, null) as SMTNode
     }
 
@@ -195,6 +195,8 @@ class SmtLibGenerator(private val schema: DbSchemaDto, private val numberOfRows:
     private fun appendQueryConstraints(smt: SMTLib, sqlQuery: Statement) {
         val tableAliases = extractTableAliases(sqlQuery)
 
+        appendJoinConstraints(smt, sqlQuery, tableAliases)
+
         if (sqlQuery is Select) { // TODO: Handle other queries
             val plainSelect = sqlQuery.selectBody as PlainSelect
             val where = plainSelect.where
@@ -210,8 +212,28 @@ class SmtLibGenerator(private val schema: DbSchemaDto, private val numberOfRows:
         }
     }
 
+    private fun appendJoinConstraints(smt: SMTLib, sqlQuery: Statement, tableAliases: Map<String, String>) {
+        if (sqlQuery is Select) { // TODO: Handle other queries
+            val plainSelect = sqlQuery.selectBody as PlainSelect
+            val joins = plainSelect.joins
+            if (joins != null) {
+                for (join in joins) {
+                    val onExpression = join.onExpression
+                    if (onExpression != null) {
+                        val condition = parser.parse(onExpression.toString(), toDBType(schema.databaseType))
+                        val tableFromQuery = TablesNamesFinder().getTables(sqlQuery as Statement).first();
+                        for (i in 1..numberOfRows) {
+                            val constraint = parseQueryCondition(tableAliases, tableFromQuery, condition, i)
+                            smt.addNode(constraint)
+                        }
+                    }
+                }
+            }
+        }
+    }
+
     private fun parseQueryCondition(tableAliases: Map<String, String>, defaultTableName: String, condition: SqlCondition, index: Int): SMTNode {
-        val visitor = SMTConditionVisitor(defaultTableName, tableAliases, index)
+        val visitor = SMTConditionVisitor(defaultTableName, tableAliases, schema.tables, index)
         return condition.accept(visitor, null) as SMTNode
     }
 

--- a/core/src/test/kotlin/org/evomaster/core/solver/SmtLibGeneratorTest.kt
+++ b/core/src/test/kotlin/org/evomaster/core/solver/SmtLibGeneratorTest.kt
@@ -18,6 +18,163 @@ import java.sql.SQLException
 
 class SmtLibGeneratorTest {
 
+    val expected = SMTLib().apply {
+        addNode(
+            DeclareDatatypeSMTNode(
+                "ProductsRow", ImmutableList.of(
+                    DeclareConstSMTNode("PRICE", "Int"),
+                    DeclareConstSMTNode("MIN_PRICE", "Int"),
+                    DeclareConstSMTNode("STOCK", "Int"),
+                    DeclareConstSMTNode("USER_ID", "Int")
+                )
+            )
+        )
+        addNode(DeclareConstSMTNode("products1", "ProductsRow"))
+        addNode(DeclareConstSMTNode("products2", "ProductsRow"))
+        addNode(
+            DeclareDatatypeSMTNode(
+                "UsersRow", ImmutableList.of(
+                    DeclareConstSMTNode("ID", "Int"),
+                    DeclareConstSMTNode("DOCUMENT", "Int"),
+                    DeclareConstSMTNode("NAME", "String"),
+                    DeclareConstSMTNode("AGE", "Int"),
+                    DeclareConstSMTNode("POINTS", "Int")
+                )
+            )
+        )
+        addNode(DeclareConstSMTNode("users1", "UsersRow"))
+        addNode(DeclareConstSMTNode("users2", "UsersRow"))
+        addNode(
+            AssertSMTNode(DistinctAssertion(listOf("(DOCUMENT users1)", "(DOCUMENT users2)")))
+        )
+        addNode(
+            AssertSMTNode(
+                EqualsAssertion(listOf("(NAME users1)", "\"agus\""))
+            )
+        )
+        addNode(
+            AssertSMTNode(
+                EqualsAssertion(listOf("(NAME users2)", "\"agus\""))
+            )
+        )
+        addNode(
+            AssertSMTNode(
+                OrAssertion(
+                    listOf(
+                        LessThanAssertion("(POINTS users1)", "4"),
+                        GreaterThanAssertion("(POINTS users1)", "6")
+                    )
+                )
+            )
+        )
+        addNode(
+            AssertSMTNode(
+                OrAssertion(
+                    listOf(
+                        LessThanAssertion("(POINTS users2)", "4"),
+                        GreaterThanAssertion("(POINTS users2)", "6")
+                    )
+                )
+            )
+        )
+        addNode(
+            AssertSMTNode(
+                AndAssertion(
+                    listOf(
+                        GreaterThanAssertion("(AGE users1)", "18"),
+                        LessThanAssertion("(AGE users1)", "100")
+                    )
+                )
+            )
+        )
+        addNode(
+            AssertSMTNode(
+                AndAssertion(
+                    listOf(
+                        GreaterThanAssertion("(AGE users2)", "18"),
+                        LessThanAssertion("(AGE users2)", "100")
+                    )
+                )
+            )
+        )
+        addNode(
+            AssertSMTNode(
+                LessThanOrEqualsAssertion("(POINTS users1)", "10")
+            )
+        )
+        addNode(
+            AssertSMTNode(
+                LessThanOrEqualsAssertion("(POINTS users2)", "10")
+            )
+        )
+        addNode(
+            AssertSMTNode(
+                GreaterThanOrEqualsAssertion("(POINTS users1)", "0")
+            )
+        )
+        addNode(
+            AssertSMTNode(
+                GreaterThanOrEqualsAssertion("(POINTS users2)", "0")
+            )
+        )
+        addNode(
+            AssertSMTNode(
+                OrAssertion(
+                    listOf(
+                        EqualsAssertion(listOf("(USER_ID products1)", "(ID users1)")),
+                        EqualsAssertion(listOf("(USER_ID products1)", "(ID users2)"))
+                    )
+                )
+            )
+        )
+        addNode(
+            AssertSMTNode(
+                OrAssertion(
+                    listOf(
+                        EqualsAssertion(listOf("(USER_ID products2)", "(ID users1)")),
+                        EqualsAssertion(listOf("(USER_ID products2)", "(ID users2)"))
+                    )
+                )
+            )
+        )
+        addNode(
+            AssertSMTNode(
+                DistinctAssertion(
+                    listOf(
+                        "(ID users1)",
+                        "(ID users2)"
+                    )
+                )
+            )
+        )
+        addNode(
+            AssertSMTNode(
+                AndAssertion(
+                    listOf(
+                        GreaterThanAssertion("(AGE users1)", "30"),
+                        EqualsAssertion(listOf("(POINTS users1)", "7"))
+                    )
+                )
+            )
+        )
+        addNode(
+            AssertSMTNode(
+                AndAssertion(
+                    listOf(
+                        GreaterThanAssertion("(AGE users2)", "30"),
+                        EqualsAssertion(listOf("(POINTS users2)", "7"))
+                    )
+                )
+            )
+        )
+        addNode(CheckSatSMTNode())
+        addNode(GetValueSMTNode("products1"))
+        addNode(GetValueSMTNode("products2"))
+        addNode(GetValueSMTNode("users1"))
+        addNode(GetValueSMTNode("users2"))
+    }
+
+
     companion object {
         private lateinit var generator: SmtLibGenerator
         private lateinit var connection: Connection
@@ -57,163 +214,23 @@ class SmtLibGeneratorTest {
     @Throws(JSQLParserException::class)
     fun selectFromUsers() {
         val selectStatement: Statement = CCJSqlParserUtil.parse("SELECT * FROM Users WHERE Age > 30 AND points = 7;")
+
         val response: SMTLib = generator.generateSMT(selectStatement)
 
-        val expected = SMTLib().apply {
-            addNode(
-                DeclareDatatypeSMTNode(
-                    "ProductsRow", ImmutableList.of(
-                        DeclareConstSMTNode("PRICE", "Int"),
-                        DeclareConstSMTNode("MIN_PRICE", "Int"),
-                        DeclareConstSMTNode("STOCK", "Int"),
-                        DeclareConstSMTNode("USER_ID", "Int")
-                    )
-                )
-            )
-            addNode(DeclareConstSMTNode("products1", "ProductsRow"))
-            addNode(DeclareConstSMTNode("products2", "ProductsRow"))
-            addNode(
-                DeclareDatatypeSMTNode(
-                    "UsersRow", ImmutableList.of(
-                        DeclareConstSMTNode("ID", "Int"),
-                        DeclareConstSMTNode("DOCUMENT", "Int"),
-                        DeclareConstSMTNode("NAME", "String"),
-                        DeclareConstSMTNode("AGE", "Int"),
-                        DeclareConstSMTNode("POINTS", "Int")
-                    )
-                )
-            )
-            addNode(DeclareConstSMTNode("users1", "UsersRow"))
-            addNode(DeclareConstSMTNode("users2", "UsersRow"))
-            addNode(
-                AssertSMTNode(DistinctAssertion(listOf("(DOCUMENT users1)", "(DOCUMENT users2)")))
-            )
-            addNode(
-                AssertSMTNode(
-                    EqualsAssertion(listOf("(NAME users1)", "\"agus\""))
-                )
-            )
-            addNode(
-                AssertSMTNode(
-                    EqualsAssertion(listOf("(NAME users2)", "\"agus\""))
-                )
-            )
-            addNode(
-                AssertSMTNode(
-                    OrAssertion(
-                        listOf(
-                            LessThanAssertion("(POINTS users1)", "4"),
-                            GreaterThanAssertion("(POINTS users1)", "6")
-                        )
-                    )
-                )
-            )
-            addNode(
-                AssertSMTNode(
-                    OrAssertion(
-                        listOf(
-                            LessThanAssertion("(POINTS users2)", "4"),
-                            GreaterThanAssertion("(POINTS users2)", "6")
-                        )
-                    )
-                )
-            )
-            addNode(
-                AssertSMTNode(
-                    AndAssertion(
-                        listOf(
-                            GreaterThanAssertion("(AGE users1)", "18"),
-                            LessThanAssertion("(AGE users1)", "100")
-                        )
-                    )
-                )
-            )
-            addNode(
-                AssertSMTNode(
-                    AndAssertion(
-                        listOf(
-                            GreaterThanAssertion("(AGE users2)", "18"),
-                            LessThanAssertion("(AGE users2)", "100")
-                        )
-                    )
-                )
-            )
-            addNode(
-                AssertSMTNode(
-                    LessThanOrEqualsAssertion("(POINTS users1)", "10")
-                )
-            )
-            addNode(
-                AssertSMTNode(
-                    LessThanOrEqualsAssertion("(POINTS users2)", "10")
-                )
-            )
-            addNode(
-                AssertSMTNode(
-                    GreaterThanOrEqualsAssertion("(POINTS users1)", "0")
-                )
-            )
-            addNode(
-                AssertSMTNode(
-                    GreaterThanOrEqualsAssertion("(POINTS users2)", "0")
-                )
-            )
-            addNode(
-                AssertSMTNode(
-                    OrAssertion(
-                        listOf(
-                            EqualsAssertion(listOf("(USER_ID products1)", "(ID users1)")),
-                            EqualsAssertion(listOf("(USER_ID products1)", "(ID users2)"))
-                        )
-                    )
-                )
-            )
-            addNode(
-                AssertSMTNode(
-                    OrAssertion(
-                        listOf(
-                            EqualsAssertion(listOf("(USER_ID products2)", "(ID users1)")),
-                            EqualsAssertion(listOf("(USER_ID products2)", "(ID users2)"))
-                        )
-                    )
-                )
-            )
-            addNode(
-                AssertSMTNode(
-                    DistinctAssertion(
-                        listOf(
-                            "(ID users1)",
-                            "(ID users2)"
-                        )
-                    )
-                )
-            )
-            addNode(
-                AssertSMTNode(
-                    AndAssertion(
-                        listOf(
-                            GreaterThanAssertion("(AGE users1)", "30"),
-                            EqualsAssertion(listOf("(POINTS users1)", "7"))
-                        )
-                    )
-                )
-            )
-            addNode(
-                AssertSMTNode(
-                    AndAssertion(
-                        listOf(
-                            GreaterThanAssertion("(AGE users2)", "30"),
-                            EqualsAssertion(listOf("(POINTS users2)", "7"))
-                        )
-                    )
-                )
-            )
-            addNode(CheckSatSMTNode())
-            addNode(GetValueSMTNode("products1"))
-            addNode(GetValueSMTNode("products2"))
-            addNode(GetValueSMTNode("users1"))
-            addNode(GetValueSMTNode("users2"))
-        }
+        assertEquals(expected, response)
+    }
+
+
+    /**
+     * Test the generation of SMT from a simple select statement and a database schema
+     * @throws JSQLParserException if the statement is not valid
+     */
+    @Test
+    @Throws(JSQLParserException::class)
+    fun selectFromUsersWithTableAlias() {
+        val selectStatement: Statement = CCJSqlParserUtil.parse("SELECT * FROM Users u WHERE u.Age > 30 AND u.points = 7;")
+
+        val response: SMTLib = generator.generateSMT(selectStatement)
 
         assertEquals(expected, response)
     }

--- a/core/src/test/kotlin/org/evomaster/core/solver/SmtLibGeneratorTest.kt
+++ b/core/src/test/kotlin/org/evomaster/core/solver/SmtLibGeneratorTest.kt
@@ -288,7 +288,7 @@ class SmtLibGeneratorTest {
         )
         expected.addNode(
             AssertSMTNode(
-                EqualsAssertion(listOf("(ID usfers2)", "(USER_ID products2)"))
+                EqualsAssertion(listOf("(ID users2)", "(USER_ID products2)"))
             )
         )
 


### PR DESCRIPTION
#### Summary

This PR enhances the `SMTConditionVisitor` and related classes to support SQL queries involving multiple tables, table aliases, and conditions with operands in different orders. Specifically, it addresses the following features:

1. **Support for Multiple Tables (JOIN)**:
   - The `SMTConditionVisitor` now supports SQL conditions involving more than one table. For example, it can handle queries like `SELECT * FROM users u JOIN products p WHERE u.age > p.min_age`.

2. **Support for Table Aliases**:
   - The `SMTConditionVisitor` and related classes can now handle queries with table aliases. For instance, it supports queries like `SELECT * FROM USERS u WHERE u.age > 30`.

3. **Support for Conditions with Operands in Different Orders**:
   - The `SMTConditionVisitor` can now process SQL conditions where the column and literal operands are in reverse order. For example, it supports conditions like `SELECT * FROM USERS WHERE 7 = age`.

#### Detailed Changes

1. **SMTConditionVisitor**:
   - Modified to support multiple tables by including a `tableAliases` map that associates aliases with their corresponding table names.
   - Enhanced the `visit` methods to reference columns using the table aliases correctly.
   - Updated the `getColumnReference` method to use the correct table name based on the alias provided.

2. **SmtLibGenerator**:
   - Updated the `appendQueryConstraints` method to pass table aliases to the `SMTConditionVisitor`.
   - Adjusted the method to handle the parsing and mapping of table aliases correctly.

3. **Example Adjustments**:
   - Adjusted the example conditions and assertions to support the new features.
