### PR TITLE
In python tests, when body is not null plaintext, content is not escaped twice

### DIFF
--- a/core/src/main/kotlin/org/evomaster/core/output/service/HttpWsTestCaseWriter.kt
+++ b/core/src/main/kotlin/org/evomaster/core/output/service/HttpWsTestCaseWriter.kt
@@ -423,7 +423,7 @@ abstract class HttpWsTestCaseWriter : ApiTestCaseWriter() {
                             lines.append("new StringContent(\"$body\", Encoding.UTF8, \"${bodyParam.contentType()}\")")
                         }
                         format.isPython() -> {
-                            lines.add("body = \"$body\"")
+                            lines.add("body = $body")
                         }
                         else -> lines.add(".$send($body)")
                     }

--- a/core/src/main/kotlin/org/evomaster/core/output/service/HttpWsTestCaseWriter.kt
+++ b/core/src/main/kotlin/org/evomaster/core/output/service/HttpWsTestCaseWriter.kt
@@ -423,7 +423,11 @@ abstract class HttpWsTestCaseWriter : ApiTestCaseWriter() {
                             lines.append("new StringContent(\"$body\", Encoding.UTF8, \"${bodyParam.contentType()}\")")
                         }
                         format.isPython() -> {
-                            lines.add("body = $body")
+                            if (body.trim().isNullOrBlank()) {
+                                lines.add("body = \"\"")
+                            } else {
+                                lines.add("body = $body")
+                            }
                         }
                         else -> lines.add(".$send($body)")
                     }


### PR DESCRIPTION
Fixed the following issues:
- text plain payloads were being escaped twice. Resulting in output code such as: `""my string""`
- Empty string resulted in a `body = ` statement, instead of `body = ""`