### PR TITLE
Change validations to check shouldGenerateSqlData instead of only search

### DIFF
--- a/core/src/main/kotlin/org/evomaster/core/EMConfig.kt
+++ b/core/src/main/kotlin/org/evomaster/core/EMConfig.kt
@@ -487,6 +487,9 @@ class EMConfig {
             throw ConfigProblemException("Cannot generate SQL data if you not enable " +
                     "collecting heuristics with 'heuristicsForSQL'")
         }
+        if (generateSqlDataWithDSE && generateSqlDataWithSearch) {
+            throw ConfigProblemException("Cannot generate SQL data with both DSE and search")
+        }
 
         if (heuristicsForSQL && !extractSqlExecutionInfo) {
             throw ConfigProblemException("Cannot collect heuristics SQL data if you not enable " +

--- a/core/src/main/kotlin/org/evomaster/core/problem/api/service/ApiWsStructureMutator.kt
+++ b/core/src/main/kotlin/org/evomaster/core/problem/api/service/ApiWsStructureMutator.kt
@@ -5,27 +5,26 @@ import org.evomaster.client.java.controller.api.dto.database.execution.MongoFail
 import org.evomaster.client.java.instrumentation.shared.ExternalServiceSharedUtils
 import org.evomaster.core.EMConfig
 import org.evomaster.core.Lazy
-import org.evomaster.core.sql.SqlAction
-import org.evomaster.core.sql.SqlActionUtils
-import org.evomaster.core.sql.SqlInsertBuilder
 import org.evomaster.core.mongo.MongoDbAction
 import org.evomaster.core.problem.api.ApiWsIndividual
 import org.evomaster.core.problem.enterprise.EnterpriseActionGroup
 import org.evomaster.core.problem.externalservice.HostnameResolutionAction
-import org.evomaster.core.problem.externalservice.httpws.service.HarvestActualHttpWsResponseHandler
-import org.evomaster.core.problem.externalservice.httpws.service.HttpWsExternalServiceHandler
 import org.evomaster.core.problem.externalservice.httpws.HttpExternalServiceAction
 import org.evomaster.core.problem.externalservice.httpws.param.HttpWsResponseParam
-import org.evomaster.core.search.action.EnvironmentAction
+import org.evomaster.core.problem.externalservice.httpws.service.HarvestActualHttpWsResponseHandler
+import org.evomaster.core.problem.externalservice.httpws.service.HttpWsExternalServiceHandler
 import org.evomaster.core.search.EvaluatedIndividual
 import org.evomaster.core.search.GroupsOfChildren
 import org.evomaster.core.search.Individual
+import org.evomaster.core.search.action.EnvironmentAction
 import org.evomaster.core.search.gene.sql.SqlForeignKeyGene
 import org.evomaster.core.search.gene.sql.SqlPrimaryKeyGene
 import org.evomaster.core.search.impact.impactinfocollection.ImpactsOfIndividual
 import org.evomaster.core.search.service.mutator.MutatedGeneSpecification
 import org.evomaster.core.search.service.mutator.StructureMutator
-import org.evomaster.core.solver.SMTLibZ3DbConstraintSolver
+import org.evomaster.core.sql.SqlAction
+import org.evomaster.core.sql.SqlActionUtils
+import org.evomaster.core.sql.SqlInsertBuilder
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import kotlin.math.max
@@ -304,11 +303,6 @@ abstract class ApiWsStructureMutator : StructureMutator() {
         return mutableListOf()
     }
 
-    private fun <T : ApiWsIndividual> handleDSE(sampler: ApiWsSampler<T>, fw: Map<String, Set<String>>): MutableList<List<SqlAction>> {
-        // TODO:
-        return mutableListOf<List<SqlAction>>()
-    }
-
     private fun <T : ApiWsIndividual> handleSearch(
         ind: T,
         sampler: ApiWsSampler<T>,
@@ -389,6 +383,11 @@ abstract class ApiWsStructureMutator : StructureMutator() {
             missing = findMissing(fw, ind.seeInitializingActions().filterIsInstance<SqlAction>())
         }
         return addedSqlInsertions
+    }
+
+    private fun <T : ApiWsIndividual> handleDSE(sampler: ApiWsSampler<T>, fw: Map<String, Set<String>>): MutableList<List<SqlAction>> {
+        /* TODO: DSE should be plugged in here */
+        return mutableListOf()
     }
 
     private fun <T : ApiWsIndividual> handleFailedFind(

--- a/core/src/main/kotlin/org/evomaster/core/problem/api/service/ApiWsStructureMutator.kt
+++ b/core/src/main/kotlin/org/evomaster/core/problem/api/service/ApiWsStructureMutator.kt
@@ -305,21 +305,8 @@ abstract class ApiWsStructureMutator : StructureMutator() {
     }
 
     private fun <T : ApiWsIndividual> handleDSE(sampler: ApiWsSampler<T>, fw: Map<String, Set<String>>): MutableList<List<SqlAction>> {
-        // TODO: Use one solver, instead of creating one each time?
-        val resourcesFolder = "/tmp";
-        val schemaDto = sampler.sqlInsertBuilder?.schemaDto
-            ?: throw IllegalStateException("No DB schema is available")
-        val solver = SMTLibZ3DbConstraintSolver(schemaDto, resourcesFolder)
-
-        val newActions = mutableListOf<List<SqlAction>>()
-        for ((_, queries) in fw) {
-            for (query in queries) {
-                val newActionsForQuery = solver.solve(query)
-                newActions.addAll(mutableListOf(newActionsForQuery))
-            }
-        }
-
-        return newActions
+        // TODO:
+        return mutableListOf<List<SqlAction>>()
     }
 
     private fun <T : ApiWsIndividual> handleSearch(

--- a/core/src/main/kotlin/org/evomaster/core/problem/rest/service/ResourceRestMutator.kt
+++ b/core/src/main/kotlin/org/evomaster/core/problem/rest/service/ResourceRestMutator.kt
@@ -27,7 +27,7 @@ class ResourceRestMutator : StandardMutator<RestIndividual>() {
             GeneFilter.NO_SQL
         ) }.filter(Gene::isMutable)
 
-        if (!config.generateSqlDataWithSearch)
+        if (!config.shouldGenerateSqlData())
             return restGenes
 
         return individual.seeInitializingActions().flatMap { it.seeTopGenes() }.filter(Gene::isMutable)

--- a/core/src/main/kotlin/org/evomaster/core/search/service/mutator/StandardMutator.kt
+++ b/core/src/main/kotlin/org/evomaster/core/search/service/mutator/StandardMutator.kt
@@ -83,7 +83,7 @@ open class StandardMutator<T> : Mutator<T>() where T : Individual {
     }
 
     override fun genesToMutation(individual: T, evi: EvaluatedIndividual<T>, targets: Set<Int>): List<Gene> {
-        val filterMutate = if (config.generateSqlDataWithSearch) ALL else NO_SQL
+        val filterMutate = if (config.shouldGenerateSqlData()) ALL else NO_SQL
         val genes = individual.seeGenes(filterMutate).filter { it.isMutable() }
         return genes
     }

--- a/core/src/main/kotlin/org/evomaster/core/sql/SqlInsertBuilder.kt
+++ b/core/src/main/kotlin/org/evomaster/core/sql/SqlInsertBuilder.kt
@@ -17,7 +17,7 @@ import org.evomaster.core.logging.LoggingUtil
 
 
 class SqlInsertBuilder(
-    public val schemaDto: DbSchemaDto,
+    schemaDto: DbSchemaDto,
     private val dbExecutor: DatabaseExecutor? = null
 ) {
 

--- a/core/src/main/kotlin/org/evomaster/core/sql/SqlInsertBuilder.kt
+++ b/core/src/main/kotlin/org/evomaster/core/sql/SqlInsertBuilder.kt
@@ -17,7 +17,7 @@ import org.evomaster.core.logging.LoggingUtil
 
 
 class SqlInsertBuilder(
-    schemaDto: DbSchemaDto,
+    public val schemaDto: DbSchemaDto,
     private val dbExecutor: DatabaseExecutor? = null
 ) {
 


### PR DESCRIPTION
This PR should not affect functionality. The changes here enable future development on `config.generateSqlDataWithDSE`.

- Replaced check from `config.generateSqlDataWithDSE` to `config.shouldGenerateSqlData()`
- Added different behavior to handle DSE and Search in `ApiWsStructureMutator`