### PR TITLE
Added formatter for test case names according to outputFormat

### DIFF
--- a/core/src/main/kotlin/org/evomaster/core/output/naming/ActionTestCaseNamingStrategy.kt
+++ b/core/src/main/kotlin/org/evomaster/core/output/naming/ActionTestCaseNamingStrategy.kt
@@ -10,7 +10,8 @@ import org.evomaster.core.search.Solution
 import org.evomaster.core.search.action.EvaluatedAction
 
 open class ActionTestCaseNamingStrategy(
-    solution: Solution<*>
+    solution: Solution<*>,
+    private val languageConventionFormatter: LanguageConventionFormatter
 ) : NumberedTestCaseNamingStrategy(solution)  {
 
 
@@ -18,7 +19,7 @@ open class ActionTestCaseNamingStrategy(
         var evaluatedAction = individual.evaluatedMainActions().last()
         var action = evaluatedAction.action as RestCallAction
 
-        return "_${action.verb}_on_${getPath(action.path.nameQualifier)}_${addResult(individual)}"
+        return "_${languageConventionFormatter.formatName(listOf(action.verb.toString(), "on", getPath(action.path.nameQualifier), addResult(individual)))}"
     }
 
     private fun getPath(nameQualifier: String): String {

--- a/core/src/main/kotlin/org/evomaster/core/output/naming/LanguageConventionFormatter.kt
+++ b/core/src/main/kotlin/org/evomaster/core/output/naming/LanguageConventionFormatter.kt
@@ -1,0 +1,35 @@
+package org.evomaster.core.output.naming
+
+import org.evomaster.core.output.OutputFormat
+
+class LanguageConventionFormatter(
+    private val outputFormat: OutputFormat
+) {
+
+    fun formatName(testKeywords: List<String>): String {
+        return when {
+            outputFormat.isJavaOrKotlin() -> formatCamelCase(testKeywords)
+            outputFormat.isPython() -> formatSnakeCase(testKeywords)
+            outputFormat.isJavaScript() -> formatPascalCase(testKeywords)
+            else -> formatCamelCase(testKeywords)
+        }
+
+    }
+
+    private fun formatCamelCase(testKeywords: List<String>): String {
+        return testKeywords.joinToString("") { capitalize(it) }.decapitalize()
+    }
+
+    private fun formatSnakeCase(testKeywords: List<String>): String {
+        return testKeywords.joinToString("_") { it }
+    }
+
+    private fun formatPascalCase(testKeywords: List<String>): String {
+        return testKeywords.joinToString("") { capitalize(it) }
+    }
+
+    fun capitalize(word: String): String {
+        return word[0].uppercaseChar() + word.substring(1).lowercase()
+    }
+
+}

--- a/core/src/main/kotlin/org/evomaster/core/output/naming/TestCaseNamingStrategyFactory.kt
+++ b/core/src/main/kotlin/org/evomaster/core/output/naming/TestCaseNamingStrategyFactory.kt
@@ -1,13 +1,17 @@
 package org.evomaster.core.output.naming
 
+import org.evomaster.core.EMConfig
 import org.evomaster.core.problem.rest.RestIndividual
 import org.evomaster.core.search.Solution
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 
 class TestCaseNamingStrategyFactory(
-    private val namingStrategy: NamingStrategy
+    private val namingStrategy: NamingStrategy,
+    private val languageConventionFormatter: LanguageConventionFormatter
 ) {
+
+    constructor(config: EMConfig): this(config.namingStrategy, LanguageConventionFormatter(config.outputFormat))
 
     companion object {
         private val log: Logger = LoggerFactory.getLogger(TestCaseNamingStrategyFactory::class.java)
@@ -18,7 +22,7 @@ class TestCaseNamingStrategyFactory(
             return NamingHelperNumberedTestCaseNamingStrategy(solution)
         } else if (namingStrategy.isAction()) {
             if (solution.individuals.any { it.individual is RestIndividual }) {
-                return ActionTestCaseNamingStrategy(solution)
+                return ActionTestCaseNamingStrategy(solution, languageConventionFormatter)
             } else {
                 log.warn("Action based naming strategy only available for REST APIs at the moment. Defaulting to Numbered strategy.")
                 return NamingHelperNumberedTestCaseNamingStrategy(solution)

--- a/core/src/main/kotlin/org/evomaster/core/output/service/TestSuiteWriter.kt
+++ b/core/src/main/kotlin/org/evomaster/core/output/service/TestSuiteWriter.kt
@@ -124,7 +124,7 @@ class TestSuiteWriter {
 
         val lines = Lines(config.outputFormat)
         val testSuiteOrganizer = TestSuiteOrganizer()
-        val namingStrategy = TestCaseNamingStrategyFactory(config.namingStrategy).create(solution)
+        val namingStrategy = TestCaseNamingStrategyFactory(config).create(solution)
 
        // activePartialOracles = partialOracles.activeOracles(solution.individuals)
 

--- a/core/src/test/kotlin/org/evomaster/core/output/naming/ActionNamingStrategyTest.kt
+++ b/core/src/test/kotlin/org/evomaster/core/output/naming/ActionNamingStrategyTest.kt
@@ -2,6 +2,7 @@ package org.evomaster.core.output.naming
 
 import com.webfuzzing.commons.faults.FaultCategory
 import org.evomaster.core.TestUtils
+import org.evomaster.core.output.OutputFormat
 import org.evomaster.core.output.Termination
 import org.evomaster.core.problem.enterprise.DetectedFault
 import org.evomaster.core.problem.enterprise.SampleType
@@ -19,10 +20,11 @@ class ActionNamingStrategyTest {
     @Test
     fun testGetOnRootPathIsIncludedInName() {
         val eIndividual = getEvaluatedIndividualWith("/")
+        val languageConventionFormatter = LanguageConventionFormatter(OutputFormat.PYTHON_UNITTEST)
 
         val solution = Solution(singletonList(eIndividual), "suitePrefix", "suiteSuffix", Termination.NONE, emptyList(), emptyList())
 
-        val namingStrategy = ActionTestCaseNamingStrategy(solution)
+        val namingStrategy = ActionTestCaseNamingStrategy(solution, languageConventionFormatter)
 
         val testCases = namingStrategy.getTestCases()
         assertEquals(1, testCases.size)
@@ -32,10 +34,11 @@ class ActionNamingStrategyTest {
     @Test
     fun testGetOnItemsPathIsIncludedInName() {
         val eIndividual = getEvaluatedIndividualWith("/items")
+        val languageConventionFormatter = LanguageConventionFormatter(OutputFormat.PYTHON_UNITTEST)
 
         val solution = Solution(singletonList(eIndividual), "suitePrefix", "suiteSuffix", Termination.NONE, emptyList(), emptyList())
 
-        val namingStrategy = ActionTestCaseNamingStrategy(solution)
+        val namingStrategy = ActionTestCaseNamingStrategy(solution, languageConventionFormatter)
 
         val testCases = namingStrategy.getTestCases()
         assertEquals(1, testCases.size)
@@ -45,10 +48,11 @@ class ActionNamingStrategyTest {
     @Test
     fun test500ResponseNamedWithInternalServerError() {
         val eIndividual = getEvaluatedIndividualWithFaults("/items", 500, singletonList(DetectedFault(FaultCategory.HTTP_STATUS_500, "items")))
+        val languageConventionFormatter = LanguageConventionFormatter(OutputFormat.PYTHON_UNITTEST)
 
         val solution = Solution(singletonList(eIndividual), "suitePrefix", "suiteSuffix", Termination.NONE, emptyList(), emptyList())
 
-        val namingStrategy = ActionTestCaseNamingStrategy(solution)
+        val namingStrategy = ActionTestCaseNamingStrategy(solution, languageConventionFormatter)
 
         val testCases = namingStrategy.getTestCases()
         assertEquals(1, testCases.size)
@@ -59,10 +63,11 @@ class ActionNamingStrategyTest {
     fun testResponseNamedWithMultipleFaults() {
         val faults = listOf(DetectedFault(FaultCategory.GQL_ERROR_FIELD, "items"), DetectedFault(FaultCategory.HTTP_INVALID_LOCATION, "items"), DetectedFault(FaultCategory.HTTP_STATUS_500, "items"))
         val eIndividual = getEvaluatedIndividualWithFaults("/items", 500, faults)
+        val languageConventionFormatter = LanguageConventionFormatter(OutputFormat.PYTHON_UNITTEST)
 
         val solution = Solution(singletonList(eIndividual), "suitePrefix", "suiteSuffix", Termination.NONE, emptyList(), emptyList())
 
-        val namingStrategy = ActionTestCaseNamingStrategy(solution)
+        val namingStrategy = ActionTestCaseNamingStrategy(solution, languageConventionFormatter)
 
         val testCases = namingStrategy.getTestCases()
         assertEquals(1, testCases.size)

--- a/core/src/test/kotlin/org/evomaster/core/output/naming/LanguageConventionFormatterTest.kt
+++ b/core/src/test/kotlin/org/evomaster/core/output/naming/LanguageConventionFormatterTest.kt
@@ -1,0 +1,32 @@
+package org.evomaster.core.output.naming
+
+import org.evomaster.core.output.OutputFormat
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class LanguageConventionFormatterTest {
+
+    @Test
+    fun testFormatToCamelCase() {
+        val testKeywords = listOf("GET", "on", "root", "returns", "200")
+        val languageConventionFormatter = LanguageConventionFormatter(OutputFormat.JAVA_JUNIT_4)
+
+        assertEquals("getOnRootReturns200", languageConventionFormatter.formatName(testKeywords))
+    }
+
+    @Test
+    fun testFormatToSnakeCase() {
+        val testKeywords = listOf("GET", "on", "root", "returns", "200")
+        val languageConventionFormatter = LanguageConventionFormatter(OutputFormat.PYTHON_UNITTEST)
+
+        assertEquals("GET_on_root_returns_200", languageConventionFormatter.formatName(testKeywords))
+    }
+
+    @Test
+    fun testFormatToPascalCase() {
+        val testKeywords = listOf("GET", "on", "root", "returns", "200")
+        val languageConventionFormatter = LanguageConventionFormatter(OutputFormat.JS_JEST)
+
+        assertEquals("GetOnRootReturns200", languageConventionFormatter.formatName(testKeywords))
+    }
+}


### PR DESCRIPTION
Test case names are now formatted according to language conventions. Those are:
- Java/Kotlin: Camel Case
- Python: Snake Case
- JS: Pascal Case
- Other: Camel Case

For doing this, the action based naming strategies will forward a list of strings to format as a test case name to the `LanguageConventionFormatter` object.