### PR TITLE
GraphQL, RPC and Web test case naming

### DIFF
--- a/core/src/main/kotlin/org/evomaster/core/output/naming/ActionTestCaseNamingStrategy.kt
+++ b/core/src/main/kotlin/org/evomaster/core/output/naming/ActionTestCaseNamingStrategy.kt
@@ -2,53 +2,36 @@ package org.evomaster.core.output.naming
 
 import com.webfuzzing.commons.faults.FaultCategory
 import org.evomaster.core.output.TestWriterUtils
-import org.evomaster.core.problem.enterprise.DetectedFaultUtils
-import org.evomaster.core.problem.httpws.HttpWsCallResult
-import org.evomaster.core.problem.rest.RestCallAction
-import org.evomaster.core.search.EvaluatedIndividual
 import org.evomaster.core.search.Solution
-import org.evomaster.core.search.action.EvaluatedAction
 
 open class ActionTestCaseNamingStrategy(
     solution: Solution<*>,
-    private val languageConventionFormatter: LanguageConventionFormatter
+    protected val languageConventionFormatter: LanguageConventionFormatter,
+    protected val nameTokens: List<String> = listOf(),
 ) : NumberedTestCaseNamingStrategy(solution)  {
 
-
-    override fun expandName(individual: EvaluatedIndividual<*>): String {
-        var evaluatedAction = individual.evaluatedMainActions().last()
-        var action = evaluatedAction.action as RestCallAction
-
-        return "_${languageConventionFormatter.formatName(listOf(action.verb.toString(), "on", getPath(action.path.nameQualifier), addResult(individual)))}"
+    protected fun formatName(): String {
+        return "_${languageConventionFormatter.formatName(nameTokens)}"
     }
 
-    private fun getPath(nameQualifier: String): String {
+    protected fun getPath(nameQualifier: String): String {
         if (nameQualifier == "/") {
             return "root"
         }
         return TestWriterUtils.safeVariableName(nameQualifier)
     }
 
-    private fun addResult(individual: EvaluatedIndividual<*>): String {
-        val detectedFaults = DetectedFaultUtils.getDetectedFaultCategories(individual)
-        if (detectedFaults.isNotEmpty()) {
-            return fault(detectedFaults)
-        }
-        return statusCode(individual.evaluatedMainActions().last())
-    }
-
-    private fun fault(faults: Set<FaultCategory>): String {
+    protected fun fault(faults: Set<FaultCategory>): String {
         if (faults.size > 1) {
-            var faultCodes = StringBuilder("showsFaults")
+            val faultCodes = StringBuilder("showsFaults")
+            /*
+              For better readability, multiple faults will be concatenated in a string separated by underscore
+              to help understand it is a list of codes. Regardless of the outputFormat and language conventions.
+             */
             faults.sortedBy { it.code }.forEach { fault -> faultCodes.append("_${fault.code}") }
             return faultCodes.toString()
         }
         return faults.first().testCaseLabel
-    }
-
-    private fun statusCode(evaluatedAction: EvaluatedAction): String {
-        var result = evaluatedAction.result as HttpWsCallResult
-        return "returns_${result.getStatusCode()}"
     }
 
 }

--- a/core/src/main/kotlin/org/evomaster/core/output/naming/ActionTestCaseNamingStrategy.kt
+++ b/core/src/main/kotlin/org/evomaster/core/output/naming/ActionTestCaseNamingStrategy.kt
@@ -10,7 +10,6 @@ import org.evomaster.core.search.action.EvaluatedAction
 abstract class ActionTestCaseNamingStrategy(
     solution: Solution<*>,
     private val languageConventionFormatter: LanguageConventionFormatter,
-    protected var nameTokens: MutableList<String> = mutableListOf(),
 ) : NumberedTestCaseNamingStrategy(solution)  {
 
     protected val on = "on"
@@ -21,7 +20,7 @@ abstract class ActionTestCaseNamingStrategy(
     protected val data = "data"
     protected val empty = "empty"
 
-    protected fun formatName(): String {
+    protected fun formatName(nameTokens: MutableList<String>): String {
         return "_${languageConventionFormatter.formatName(nameTokens)}"
     }
 
@@ -45,15 +44,15 @@ abstract class ActionTestCaseNamingStrategy(
         return faults.first().testCaseLabel
     }
 
-    protected fun addResult(individual: EvaluatedIndividual<*>) {
+    protected fun addResult(individual: EvaluatedIndividual<*>, nameTokens: MutableList<String>) {
         val detectedFaults = DetectedFaultUtils.getDetectedFaultCategories(individual)
         if (detectedFaults.isNotEmpty()) {
             nameTokens.add(fault(detectedFaults))
         } else {
-            addActionResult(individual.evaluatedMainActions().last())
+            addActionResult(individual.evaluatedMainActions().last(), nameTokens)
         }
     }
 
-    protected abstract fun addActionResult(evaluatedAction: EvaluatedAction)
+    protected abstract fun addActionResult(evaluatedAction: EvaluatedAction, nameTokens: MutableList<String>)
 
 }

--- a/core/src/main/kotlin/org/evomaster/core/output/naming/ActionTestCaseNamingStrategy.kt
+++ b/core/src/main/kotlin/org/evomaster/core/output/naming/ActionTestCaseNamingStrategy.kt
@@ -2,13 +2,24 @@ package org.evomaster.core.output.naming
 
 import com.webfuzzing.commons.faults.FaultCategory
 import org.evomaster.core.output.TestWriterUtils
+import org.evomaster.core.problem.enterprise.DetectedFaultUtils
+import org.evomaster.core.search.EvaluatedIndividual
 import org.evomaster.core.search.Solution
+import org.evomaster.core.search.action.EvaluatedAction
 
-open class ActionTestCaseNamingStrategy(
+abstract class ActionTestCaseNamingStrategy(
     solution: Solution<*>,
-    protected val languageConventionFormatter: LanguageConventionFormatter,
-    protected val nameTokens: List<String> = listOf(),
+    private val languageConventionFormatter: LanguageConventionFormatter,
+    protected var nameTokens: MutableList<String> = mutableListOf(),
 ) : NumberedTestCaseNamingStrategy(solution)  {
+
+    protected val on = "on"
+    protected val throws = "throws"
+    protected val returns = "returns"
+    protected val error = "error"
+    protected val success = "success"
+    protected val data = "data"
+    protected val empty = "empty"
 
     protected fun formatName(): String {
         return "_${languageConventionFormatter.formatName(nameTokens)}"
@@ -21,7 +32,7 @@ open class ActionTestCaseNamingStrategy(
         return TestWriterUtils.safeVariableName(nameQualifier)
     }
 
-    protected fun fault(faults: Set<FaultCategory>): String {
+    private fun fault(faults: Set<FaultCategory>): String {
         if (faults.size > 1) {
             val faultCodes = StringBuilder("showsFaults")
             /*
@@ -33,5 +44,16 @@ open class ActionTestCaseNamingStrategy(
         }
         return faults.first().testCaseLabel
     }
+
+    protected fun addResult(individual: EvaluatedIndividual<*>) {
+        val detectedFaults = DetectedFaultUtils.getDetectedFaultCategories(individual)
+        if (detectedFaults.isNotEmpty()) {
+            nameTokens.add(fault(detectedFaults))
+        } else {
+            addActionResult(individual.evaluatedMainActions().last())
+        }
+    }
+
+    protected abstract fun addActionResult(evaluatedAction: EvaluatedAction)
 
 }

--- a/core/src/main/kotlin/org/evomaster/core/output/naming/ActionTestCaseNamingStrategy.kt
+++ b/core/src/main/kotlin/org/evomaster/core/output/naming/ActionTestCaseNamingStrategy.kt
@@ -20,7 +20,7 @@ abstract class ActionTestCaseNamingStrategy(
     protected val data = "data"
     protected val empty = "empty"
 
-    protected fun formatName(nameTokens: MutableList<String>): String {
+    protected fun formatName(nameTokens: List<String>): String {
         return "_${languageConventionFormatter.formatName(nameTokens)}"
     }
 

--- a/core/src/main/kotlin/org/evomaster/core/output/naming/GraphQLActionTestCaseNamingStrategy.kt
+++ b/core/src/main/kotlin/org/evomaster/core/output/naming/GraphQLActionTestCaseNamingStrategy.kt
@@ -1,0 +1,49 @@
+package org.evomaster.core.output.naming
+
+import org.evomaster.core.problem.enterprise.DetectedFaultUtils
+import org.evomaster.core.problem.graphql.GraphQLAction
+import org.evomaster.core.problem.graphql.GraphQlCallResult
+import org.evomaster.core.problem.rest.RestCallAction
+import org.evomaster.core.search.EvaluatedIndividual
+import org.evomaster.core.search.Solution
+import org.evomaster.core.search.action.EvaluatedAction
+
+open class GraphQLActionTestCaseNamingStrategy(
+    solution: Solution<*>,
+    languageConventionFormatter: LanguageConventionFormatter
+) : ActionTestCaseNamingStrategy(solution, languageConventionFormatter)  {
+
+
+    override fun expandName(individual: EvaluatedIndividual<*>): String {
+        var evaluatedAction = individual.evaluatedMainActions().last()
+        var action = evaluatedAction.action as GraphQLAction
+
+        nameTokens.plus(action.methodType.toString(), "on", )
+        nameTokens.plus(getPath(action.methodName))
+        nameTokens.plus(addResult(individual))
+
+        return formatName()
+    }
+
+    private fun addResult(individual: EvaluatedIndividual<*>) {
+        val detectedFaults = DetectedFaultUtils.getDetectedFaultCategories(individual)
+        if (detectedFaults.isNotEmpty()) {
+            nameTokens.plus(fault(detectedFaults))
+        }
+        return addGraphQLResult(individual.evaluatedMainActions().last())
+    }
+
+    private fun addGraphQLResult(evaluatedAction: EvaluatedAction): List<String> {
+        val result = evaluatedAction.result as GraphQlCallResult
+        val ret = listOf("returns")
+        ret.plus(
+            when {
+                result.hasErrors() -> "error"
+                result.hasNonEmptyData() -> "data"
+                else -> "empty"
+            }
+        )
+        return ret
+    }
+
+}

--- a/core/src/main/kotlin/org/evomaster/core/output/naming/GraphQLActionTestCaseNamingStrategy.kt
+++ b/core/src/main/kotlin/org/evomaster/core/output/naming/GraphQLActionTestCaseNamingStrategy.kt
@@ -13,8 +13,8 @@ open class GraphQLActionTestCaseNamingStrategy(
 
 
     override fun expandName(individual: EvaluatedIndividual<*>, nameTokens: MutableList<String>): String {
-        var evaluatedAction = individual.evaluatedMainActions().last()
-        var action = evaluatedAction.action as GraphQLAction
+        val evaluatedAction = individual.evaluatedMainActions().last()
+        val action = evaluatedAction.action as GraphQLAction
 
         nameTokens.add(action.methodType.toString())
         nameTokens.add(on)

--- a/core/src/main/kotlin/org/evomaster/core/output/naming/GraphQLActionTestCaseNamingStrategy.kt
+++ b/core/src/main/kotlin/org/evomaster/core/output/naming/GraphQLActionTestCaseNamingStrategy.kt
@@ -12,19 +12,19 @@ open class GraphQLActionTestCaseNamingStrategy(
 ) : ActionTestCaseNamingStrategy(solution, languageConventionFormatter)  {
 
 
-    override fun expandName(individual: EvaluatedIndividual<*>): String {
+    override fun expandName(individual: EvaluatedIndividual<*>, nameTokens: MutableList<String>): String {
         var evaluatedAction = individual.evaluatedMainActions().last()
         var action = evaluatedAction.action as GraphQLAction
 
         nameTokens.add(action.methodType.toString())
         nameTokens.add(on)
         nameTokens.add(getPath(action.methodName))
-        addResult(individual)
+        addResult(individual, nameTokens)
 
-        return formatName()
+        return formatName(nameTokens)
     }
 
-    override fun addActionResult(evaluatedAction: EvaluatedAction) {
+    override fun addActionResult(evaluatedAction: EvaluatedAction, nameTokens: MutableList<String>) {
         val result = evaluatedAction.result as GraphQlCallResult
         nameTokens.add(returns)
         nameTokens.add(

--- a/core/src/main/kotlin/org/evomaster/core/output/naming/GraphQLActionTestCaseNamingStrategy.kt
+++ b/core/src/main/kotlin/org/evomaster/core/output/naming/GraphQLActionTestCaseNamingStrategy.kt
@@ -1,9 +1,7 @@
 package org.evomaster.core.output.naming
 
-import org.evomaster.core.problem.enterprise.DetectedFaultUtils
 import org.evomaster.core.problem.graphql.GraphQLAction
 import org.evomaster.core.problem.graphql.GraphQlCallResult
-import org.evomaster.core.problem.rest.RestCallAction
 import org.evomaster.core.search.EvaluatedIndividual
 import org.evomaster.core.search.Solution
 import org.evomaster.core.search.action.EvaluatedAction
@@ -18,32 +16,24 @@ open class GraphQLActionTestCaseNamingStrategy(
         var evaluatedAction = individual.evaluatedMainActions().last()
         var action = evaluatedAction.action as GraphQLAction
 
-        nameTokens.plus(action.methodType.toString(), "on", )
-        nameTokens.plus(getPath(action.methodName))
-        nameTokens.plus(addResult(individual))
+        nameTokens.add(action.methodType.toString())
+        nameTokens.add(on)
+        nameTokens.add(getPath(action.methodName))
+        addResult(individual)
 
         return formatName()
     }
 
-    private fun addResult(individual: EvaluatedIndividual<*>) {
-        val detectedFaults = DetectedFaultUtils.getDetectedFaultCategories(individual)
-        if (detectedFaults.isNotEmpty()) {
-            nameTokens.plus(fault(detectedFaults))
-        }
-        return addGraphQLResult(individual.evaluatedMainActions().last())
-    }
-
-    private fun addGraphQLResult(evaluatedAction: EvaluatedAction): List<String> {
+    override fun addActionResult(evaluatedAction: EvaluatedAction) {
         val result = evaluatedAction.result as GraphQlCallResult
-        val ret = listOf("returns")
-        ret.plus(
+        nameTokens.add(returns)
+        nameTokens.add(
             when {
-                result.hasErrors() -> "error"
-                result.hasNonEmptyData() -> "data"
-                else -> "empty"
+                result.hasErrors() -> error
+                result.hasNonEmptyData() -> data
+                else -> empty
             }
         )
-        return ret
     }
 
 }

--- a/core/src/main/kotlin/org/evomaster/core/output/naming/NamingHelperNumberedTestCaseNamingStrategy.kt
+++ b/core/src/main/kotlin/org/evomaster/core/output/naming/NamingHelperNumberedTestCaseNamingStrategy.kt
@@ -10,7 +10,7 @@ class NamingHelperNumberedTestCaseNamingStrategy(
 
     private val namingHelper = NamingHelper()
 
-    override fun expandName(individual: EvaluatedIndividual<*>): String {
+    override fun expandName(individual: EvaluatedIndividual<*>, nameTokens: MutableList<String>): String {
         return namingHelper.suggestName(individual)
     }
 }

--- a/core/src/main/kotlin/org/evomaster/core/output/naming/NumberedTestCaseNamingStrategy.kt
+++ b/core/src/main/kotlin/org/evomaster/core/output/naming/NumberedTestCaseNamingStrategy.kt
@@ -25,6 +25,7 @@ open class NumberedTestCaseNamingStrategy(
         return ""
     }
 
+    // kicking off with an empty mutableListOf for each test case to accumulate their own name tokens
     private fun getName(counter: Int, individual: EvaluatedIndividual<*>): String {
         return "test_${counter}${expandName(individual, mutableListOf())}"
     }

--- a/core/src/main/kotlin/org/evomaster/core/output/naming/NumberedTestCaseNamingStrategy.kt
+++ b/core/src/main/kotlin/org/evomaster/core/output/naming/NumberedTestCaseNamingStrategy.kt
@@ -21,12 +21,12 @@ open class NumberedTestCaseNamingStrategy(
     }
 
     // numbered strategy will not expand the name unless it is using the namingHelper
-    override fun expandName(individual: EvaluatedIndividual<*>): String {
+    override fun expandName(individual: EvaluatedIndividual<*>, nameTokens: MutableList<String>): String {
         return ""
     }
 
     private fun getName(counter: Int, individual: EvaluatedIndividual<*>): String {
-        return "test_${counter}${expandName(individual)}"
+        return "test_${counter}${expandName(individual, mutableListOf())}"
     }
 
     private fun generateNames(individuals: List<EvaluatedIndividual<*>>) : List<TestCase> {

--- a/core/src/main/kotlin/org/evomaster/core/output/naming/RPCActionTestCaseNamingStrategy.kt
+++ b/core/src/main/kotlin/org/evomaster/core/output/naming/RPCActionTestCaseNamingStrategy.kt
@@ -1,0 +1,29 @@
+package org.evomaster.core.output.naming
+
+import org.evomaster.core.problem.enterprise.DetectedFaultUtils
+import org.evomaster.core.problem.rest.RestCallAction
+import org.evomaster.core.search.EvaluatedIndividual
+import org.evomaster.core.search.Solution
+
+open class RPCActionTestCaseNamingStrategy(
+    solution: Solution<*>,
+    languageConventionFormatter: LanguageConventionFormatter
+) : ActionTestCaseNamingStrategy(solution, languageConventionFormatter)  {
+
+
+    override fun expandName(individual: EvaluatedIndividual<*>): String {
+        var evaluatedAction = individual.evaluatedMainActions().last()
+        var action = evaluatedAction.action as RestCallAction
+
+        return "_${languageConventionFormatter.formatName(listOf(action.verb.toString(), "on", getPath(action.path.nameQualifier), addResult(individual)))}"
+    }
+
+    private fun addResult(individual: EvaluatedIndividual<*>): String {
+        val detectedFaults = DetectedFaultUtils.getDetectedFaultCategories(individual)
+        if (detectedFaults.isNotEmpty()) {
+            return fault(detectedFaults)
+        }
+        return statusCode(individual.evaluatedMainActions().last())
+    }
+
+}

--- a/core/src/main/kotlin/org/evomaster/core/output/naming/RPCActionTestCaseNamingStrategy.kt
+++ b/core/src/main/kotlin/org/evomaster/core/output/naming/RPCActionTestCaseNamingStrategy.kt
@@ -16,8 +16,8 @@ open class RPCActionTestCaseNamingStrategy(
         var evaluatedAction = individual.evaluatedMainActions().last()
         var action = evaluatedAction.action as RPCCallAction
 
-        nameTokens.add(action.interfaceId)
-        nameTokens.add(action.id)
+//        nameTokens.add(TestWriterUtils.safeVariableName(action.interfaceId))
+        nameTokens.add(TestWriterUtils.safeVariableName(action.id))
         addResult(individual, nameTokens)
 
         return formatName(nameTokens)

--- a/core/src/main/kotlin/org/evomaster/core/output/naming/RPCActionTestCaseNamingStrategy.kt
+++ b/core/src/main/kotlin/org/evomaster/core/output/naming/RPCActionTestCaseNamingStrategy.kt
@@ -12,18 +12,18 @@ open class RPCActionTestCaseNamingStrategy(
     languageConventionFormatter: LanguageConventionFormatter
 ) : ActionTestCaseNamingStrategy(solution, languageConventionFormatter)  {
 
-    override fun expandName(individual: EvaluatedIndividual<*>): String {
+    override fun expandName(individual: EvaluatedIndividual<*>, nameTokens: MutableList<String>): String {
         var evaluatedAction = individual.evaluatedMainActions().last()
         var action = evaluatedAction.action as RPCCallAction
 
         nameTokens.add(action.interfaceId)
         nameTokens.add(action.id)
-        addResult(individual)
+        addResult(individual, nameTokens)
 
-        return formatName()
+        return formatName(nameTokens)
     }
 
-    override fun addActionResult(evaluatedAction: EvaluatedAction) {
+    override fun addActionResult(evaluatedAction: EvaluatedAction, nameTokens: MutableList<String>) {
         val result = evaluatedAction.result as RPCCallResult
         if (result.hasPotentialFault()) {
             nameTokens.add(throws)

--- a/core/src/main/kotlin/org/evomaster/core/output/naming/RPCActionTestCaseNamingStrategy.kt
+++ b/core/src/main/kotlin/org/evomaster/core/output/naming/RPCActionTestCaseNamingStrategy.kt
@@ -16,8 +16,9 @@ open class RPCActionTestCaseNamingStrategy(
         var evaluatedAction = individual.evaluatedMainActions().last()
         var action = evaluatedAction.action as RPCCallAction
 
-//        nameTokens.add(TestWriterUtils.safeVariableName(action.interfaceId))
-        nameTokens.add(TestWriterUtils.safeVariableName(action.id))
+        nameTokens.add(TestWriterUtils.safeVariableName(action.getSimpleClassName()))
+        nameTokens.add(on)
+        nameTokens.add(TestWriterUtils.safeVariableName(action.getExecutedFunctionName()))
         addResult(individual, nameTokens)
 
         return formatName(nameTokens)

--- a/core/src/main/kotlin/org/evomaster/core/output/naming/RPCActionTestCaseNamingStrategy.kt
+++ b/core/src/main/kotlin/org/evomaster/core/output/naming/RPCActionTestCaseNamingStrategy.kt
@@ -13,8 +13,8 @@ open class RPCActionTestCaseNamingStrategy(
 ) : ActionTestCaseNamingStrategy(solution, languageConventionFormatter)  {
 
     override fun expandName(individual: EvaluatedIndividual<*>, nameTokens: MutableList<String>): String {
-        var evaluatedAction = individual.evaluatedMainActions().last()
-        var action = evaluatedAction.action as RPCCallAction
+        val evaluatedAction = individual.evaluatedMainActions().last()
+        val action = evaluatedAction.action as RPCCallAction
 
         nameTokens.add(TestWriterUtils.safeVariableName(action.getSimpleClassName()))
         nameTokens.add(on)

--- a/core/src/main/kotlin/org/evomaster/core/output/naming/RestActionTestCaseNamingStrategy.kt
+++ b/core/src/main/kotlin/org/evomaster/core/output/naming/RestActionTestCaseNamingStrategy.kt
@@ -11,19 +11,19 @@ open class RestActionTestCaseNamingStrategy(
     languageConventionFormatter: LanguageConventionFormatter
 ) : ActionTestCaseNamingStrategy(solution, languageConventionFormatter)  {
 
-    override fun expandName(individual: EvaluatedIndividual<*>): String {
+    override fun expandName(individual: EvaluatedIndividual<*>, nameTokens: MutableList<String>): String {
         var evaluatedAction = individual.evaluatedMainActions().last()
         var action = evaluatedAction.action as RestCallAction
 
         nameTokens.add(action.verb.toString())
         nameTokens.add(on)
         nameTokens.add(getPath(action.path.nameQualifier))
-        addResult(individual)
+        addResult(individual, nameTokens)
 
-        return formatName()
+        return formatName(nameTokens)
     }
 
-    override fun addActionResult(evaluatedAction: EvaluatedAction) {
+    override fun addActionResult(evaluatedAction: EvaluatedAction, nameTokens: MutableList<String>) {
         var result = evaluatedAction.result as HttpWsCallResult
         nameTokens.add(returns)
         nameTokens.add(result.getStatusCode().toString())

--- a/core/src/main/kotlin/org/evomaster/core/output/naming/RestActionTestCaseNamingStrategy.kt
+++ b/core/src/main/kotlin/org/evomaster/core/output/naming/RestActionTestCaseNamingStrategy.kt
@@ -1,6 +1,5 @@
 package org.evomaster.core.output.naming
 
-import org.evomaster.core.problem.enterprise.DetectedFaultUtils
 import org.evomaster.core.problem.httpws.HttpWsCallResult
 import org.evomaster.core.problem.rest.RestCallAction
 import org.evomaster.core.search.EvaluatedIndividual
@@ -12,25 +11,22 @@ open class RestActionTestCaseNamingStrategy(
     languageConventionFormatter: LanguageConventionFormatter
 ) : ActionTestCaseNamingStrategy(solution, languageConventionFormatter)  {
 
-
     override fun expandName(individual: EvaluatedIndividual<*>): String {
         var evaluatedAction = individual.evaluatedMainActions().last()
         var action = evaluatedAction.action as RestCallAction
 
-        return "_${languageConventionFormatter.formatName(listOf(action.verb.toString(), "on", getPath(action.path.nameQualifier), addResult(individual)))}"
+        nameTokens.add(action.verb.toString())
+        nameTokens.add(on)
+        nameTokens.add(getPath(action.path.nameQualifier))
+        addResult(individual)
+
+        return formatName()
     }
 
-    private fun addResult(individual: EvaluatedIndividual<*>): String {
-        val detectedFaults = DetectedFaultUtils.getDetectedFaultCategories(individual)
-        if (detectedFaults.isNotEmpty()) {
-            return fault(detectedFaults)
-        }
-        return statusCode(individual.evaluatedMainActions().last())
-    }
-
-    private fun statusCode(evaluatedAction: EvaluatedAction): String {
+    override fun addActionResult(evaluatedAction: EvaluatedAction) {
         var result = evaluatedAction.result as HttpWsCallResult
-        return "returns_${result.getStatusCode()}"
+        nameTokens.add(returns)
+        nameTokens.add(result.getStatusCode().toString())
     }
 
 }

--- a/core/src/main/kotlin/org/evomaster/core/output/naming/RestActionTestCaseNamingStrategy.kt
+++ b/core/src/main/kotlin/org/evomaster/core/output/naming/RestActionTestCaseNamingStrategy.kt
@@ -1,0 +1,36 @@
+package org.evomaster.core.output.naming
+
+import org.evomaster.core.problem.enterprise.DetectedFaultUtils
+import org.evomaster.core.problem.httpws.HttpWsCallResult
+import org.evomaster.core.problem.rest.RestCallAction
+import org.evomaster.core.search.EvaluatedIndividual
+import org.evomaster.core.search.Solution
+import org.evomaster.core.search.action.EvaluatedAction
+
+open class RestActionTestCaseNamingStrategy(
+    solution: Solution<*>,
+    languageConventionFormatter: LanguageConventionFormatter
+) : ActionTestCaseNamingStrategy(solution, languageConventionFormatter)  {
+
+
+    override fun expandName(individual: EvaluatedIndividual<*>): String {
+        var evaluatedAction = individual.evaluatedMainActions().last()
+        var action = evaluatedAction.action as RestCallAction
+
+        return "_${languageConventionFormatter.formatName(listOf(action.verb.toString(), "on", getPath(action.path.nameQualifier), addResult(individual)))}"
+    }
+
+    private fun addResult(individual: EvaluatedIndividual<*>): String {
+        val detectedFaults = DetectedFaultUtils.getDetectedFaultCategories(individual)
+        if (detectedFaults.isNotEmpty()) {
+            return fault(detectedFaults)
+        }
+        return statusCode(individual.evaluatedMainActions().last())
+    }
+
+    private fun statusCode(evaluatedAction: EvaluatedAction): String {
+        var result = evaluatedAction.result as HttpWsCallResult
+        return "returns_${result.getStatusCode()}"
+    }
+
+}

--- a/core/src/main/kotlin/org/evomaster/core/output/naming/RestActionTestCaseNamingStrategy.kt
+++ b/core/src/main/kotlin/org/evomaster/core/output/naming/RestActionTestCaseNamingStrategy.kt
@@ -12,8 +12,8 @@ open class RestActionTestCaseNamingStrategy(
 ) : ActionTestCaseNamingStrategy(solution, languageConventionFormatter)  {
 
     override fun expandName(individual: EvaluatedIndividual<*>, nameTokens: MutableList<String>): String {
-        var evaluatedAction = individual.evaluatedMainActions().last()
-        var action = evaluatedAction.action as RestCallAction
+        val evaluatedAction = individual.evaluatedMainActions().last()
+        val action = evaluatedAction.action as RestCallAction
 
         nameTokens.add(action.verb.toString())
         nameTokens.add(on)
@@ -24,7 +24,7 @@ open class RestActionTestCaseNamingStrategy(
     }
 
     override fun addActionResult(evaluatedAction: EvaluatedAction, nameTokens: MutableList<String>) {
-        var result = evaluatedAction.result as HttpWsCallResult
+        val result = evaluatedAction.result as HttpWsCallResult
         nameTokens.add(returns)
         nameTokens.add(result.getStatusCode().toString())
     }

--- a/core/src/main/kotlin/org/evomaster/core/output/naming/TestCaseNamingStrategy.kt
+++ b/core/src/main/kotlin/org/evomaster/core/output/naming/TestCaseNamingStrategy.kt
@@ -29,6 +29,6 @@ abstract class TestCaseNamingStrategy(
      *
      * @return a String with extra information that will be included in the test name, regarding the EvaluatedIndividual
      */
-    protected abstract fun expandName(individual: EvaluatedIndividual<*>): String
+    protected abstract fun expandName(individual: EvaluatedIndividual<*>, nameTokens: MutableList<String>): String
 
 }

--- a/core/src/main/kotlin/org/evomaster/core/output/naming/TestCaseNamingStrategy.kt
+++ b/core/src/main/kotlin/org/evomaster/core/output/naming/TestCaseNamingStrategy.kt
@@ -26,6 +26,7 @@ abstract class TestCaseNamingStrategy(
 
     /**
      * @param individual containing information for the test about to be named
+     * @param nameTokens list to collect the identifiers which will be formatted into the test case name
      *
      * @return a String with extra information that will be included in the test name, regarding the EvaluatedIndividual
      */

--- a/core/src/main/kotlin/org/evomaster/core/output/naming/TestCaseNamingStrategyFactory.kt
+++ b/core/src/main/kotlin/org/evomaster/core/output/naming/TestCaseNamingStrategyFactory.kt
@@ -1,7 +1,10 @@
 package org.evomaster.core.output.naming
 
 import org.evomaster.core.EMConfig
+import org.evomaster.core.problem.graphql.GraphQLIndividual
 import org.evomaster.core.problem.rest.RestIndividual
+import org.evomaster.core.problem.rpc.RPCIndividual
+import org.evomaster.core.problem.webfrontend.WebIndividual
 import org.evomaster.core.search.Solution
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
@@ -18,16 +21,25 @@ class TestCaseNamingStrategyFactory(
     }
 
     fun create(solution: Solution<*>): TestCaseNamingStrategy {
-        if (namingStrategy.isNumbered()) {
-            return NamingHelperNumberedTestCaseNamingStrategy(solution)
-        } else if (namingStrategy.isAction()) {
-            if (solution.individuals.any { it.individual is RestIndividual }) {
-                return ActionTestCaseNamingStrategy(solution, languageConventionFormatter)
-            } else {
-                log.warn("Action based naming strategy only available for REST APIs at the moment. Defaulting to Numbered strategy.")
+        return when {
+            namingStrategy.isNumbered() -> NamingHelperNumberedTestCaseNamingStrategy(solution)
+            namingStrategy.isAction() -> actionBasedNamingStrategy(solution)
+            else -> throw IllegalStateException("Unrecognized naming strategy $namingStrategy")
+        }
+    }
+
+    private fun actionBasedNamingStrategy(solution: Solution<*>): NumberedTestCaseNamingStrategy {
+        val individuals = solution.individuals
+        return when {
+            individuals.any { it.individual is RestIndividual } -> return RestActionTestCaseNamingStrategy(solution, languageConventionFormatter)
+            individuals.any { it.individual is GraphQLIndividual } -> return GraphQLActionTestCaseNamingStrategy(solution, languageConventionFormatter)
+            individuals.any { it.individual is RPCIndividual } -> return RPCActionTestCaseNamingStrategy(solution, languageConventionFormatter)
+            individuals.any { it.individual is WebIndividual } -> {
+                log.warn("Web individuals do not have action based test case naming yet. Defaulting to Numbered strategy.")
                 return NamingHelperNumberedTestCaseNamingStrategy(solution)
             }
+            else -> throw IllegalStateException("Unrecognized test individuals with no action based naming strategy set.")
         }
-        throw IllegalStateException("Unrecognized naming strategy $namingStrategy")
     }
+
 }

--- a/core/src/main/kotlin/org/evomaster/core/problem/graphql/GraphQlCallResult.kt
+++ b/core/src/main/kotlin/org/evomaster/core/problem/graphql/GraphQlCallResult.kt
@@ -11,7 +11,7 @@ class GraphQlCallResult : HttpWsCallResult {
 
     companion object{
         const val LAST_STATEMENT_WHEN_GQL_ERRORS = "LAST_STATEMENT_WHEN_GQL_ERRORS"
-        private val mapper: ObjectMapper = ObjectMapper()
+        private val mapper = ObjectMapper()
     }
 
     constructor(sourceLocalId: String, stopping: Boolean = false) : super(sourceLocalId, stopping)

--- a/core/src/main/kotlin/org/evomaster/core/problem/rpc/RPCCallAction.kt
+++ b/core/src/main/kotlin/org/evomaster/core/problem/rpc/RPCCallAction.kt
@@ -55,6 +55,31 @@ open class RPCCallAction(
     }
 
     /**
+     * RPC is only available for Java or Kotlin.
+     * Therefore, it will assume JVM like package naming structure to find the class name.
+     *
+     * @return the simple class name of a Java or Kotlin class representing the service
+     */
+    fun getSimpleClassName(): String {
+        return extractSimpleClass(id.split(":")[0])
+    }
+
+    private fun extractSimpleClass(fullyQualifiedName: String) : String {
+        if (fullyQualifiedName.isNullOrEmpty()) return ""
+
+        // Replace $ with . and then split by . to handle inner classes
+        val parts = fullyQualifiedName.replace('$', '.').split(".")
+        return parts.last()
+    }
+
+    /**
+     * @return the function name being executed
+     */
+    fun getExecutedFunctionName(): String {
+        return id.split(":")[1]
+    }
+
+    /**
      * reset response info
      */
     fun resetResponse() {

--- a/core/src/test/kotlin/org/evomaster/core/output/naming/ActionNamingStrategyTest.kt
+++ b/core/src/test/kotlin/org/evomaster/core/output/naming/ActionNamingStrategyTest.kt
@@ -24,7 +24,7 @@ class ActionNamingStrategyTest {
 
         val solution = Solution(singletonList(eIndividual), "suitePrefix", "suiteSuffix", Termination.NONE, emptyList(), emptyList())
 
-        val namingStrategy = ActionTestCaseNamingStrategy(solution, languageConventionFormatter)
+        val namingStrategy = RestActionTestCaseNamingStrategy(solution, languageConventionFormatter)
 
         val testCases = namingStrategy.getTestCases()
         assertEquals(1, testCases.size)
@@ -38,7 +38,7 @@ class ActionNamingStrategyTest {
 
         val solution = Solution(singletonList(eIndividual), "suitePrefix", "suiteSuffix", Termination.NONE, emptyList(), emptyList())
 
-        val namingStrategy = ActionTestCaseNamingStrategy(solution, languageConventionFormatter)
+        val namingStrategy = RestActionTestCaseNamingStrategy(solution, languageConventionFormatter)
 
         val testCases = namingStrategy.getTestCases()
         assertEquals(1, testCases.size)
@@ -52,7 +52,7 @@ class ActionNamingStrategyTest {
 
         val solution = Solution(singletonList(eIndividual), "suitePrefix", "suiteSuffix", Termination.NONE, emptyList(), emptyList())
 
-        val namingStrategy = ActionTestCaseNamingStrategy(solution, languageConventionFormatter)
+        val namingStrategy = RestActionTestCaseNamingStrategy(solution, languageConventionFormatter)
 
         val testCases = namingStrategy.getTestCases()
         assertEquals(1, testCases.size)
@@ -67,7 +67,7 @@ class ActionNamingStrategyTest {
 
         val solution = Solution(singletonList(eIndividual), "suitePrefix", "suiteSuffix", Termination.NONE, emptyList(), emptyList())
 
-        val namingStrategy = ActionTestCaseNamingStrategy(solution, languageConventionFormatter)
+        val namingStrategy = RestActionTestCaseNamingStrategy(solution, languageConventionFormatter)
 
         val testCases = namingStrategy.getTestCases()
         assertEquals(1, testCases.size)

--- a/core/src/test/kotlin/org/evomaster/core/output/naming/GraphQLActionNamingStrategyTest.kt
+++ b/core/src/test/kotlin/org/evomaster/core/output/naming/GraphQLActionNamingStrategyTest.kt
@@ -1,0 +1,90 @@
+package org.evomaster.core.output.naming
+
+import com.webfuzzing.commons.faults.FaultCategory
+import org.evomaster.core.TestUtils
+import org.evomaster.core.output.OutputFormat
+import org.evomaster.core.output.Termination
+import org.evomaster.core.problem.enterprise.DetectedFault
+import org.evomaster.core.problem.enterprise.EnterpriseActionGroup
+import org.evomaster.core.problem.enterprise.SampleType
+import org.evomaster.core.problem.graphql.GQMethodType
+import org.evomaster.core.problem.graphql.GraphQLAction
+import org.evomaster.core.problem.graphql.GraphQLIndividual
+import org.evomaster.core.problem.graphql.GraphQlCallResult
+import org.evomaster.core.problem.graphql.param.GQInputParam
+import org.evomaster.core.search.EvaluatedIndividual
+import org.evomaster.core.search.FitnessValue
+import org.evomaster.core.search.Solution
+import org.evomaster.core.search.gene.optional.OptionalGene
+import org.evomaster.core.search.gene.string.StringGene
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import java.util.Collections.singletonList
+
+
+class GraphQLActionNamingStrategyTest {
+
+    @Test
+    fun testMutationOnAddReturnsEmpty() {
+        val eIndividual = getEvaluatedIndividualWith(GQMethodType.MUTATION)
+        val languageConventionFormatter = LanguageConventionFormatter(OutputFormat.PYTHON_UNITTEST)
+
+        val solution = Solution(singletonList(eIndividual), "suitePrefix", "suiteSuffix", Termination.NONE, emptyList(), emptyList())
+
+        val namingStrategy = GraphQLActionTestCaseNamingStrategy(solution, languageConventionFormatter)
+
+        val testCases = namingStrategy.getTestCases()
+        assertEquals(1, testCases.size)
+        assertEquals("test_0_MUTATION_on_add_returns_empty", testCases[0].name)
+    }
+
+    @Test
+    fun testQueryOnAddReturnsData() {
+        val eIndividual = getEvaluatedIndividualWith(GQMethodType.QUERY)
+        val languageConventionFormatter = LanguageConventionFormatter(OutputFormat.PYTHON_UNITTEST)
+
+        val solution = Solution(singletonList(eIndividual), "suitePrefix", "suiteSuffix", Termination.NONE, emptyList(), emptyList())
+
+        val namingStrategy = GraphQLActionTestCaseNamingStrategy(solution, languageConventionFormatter)
+
+        val testCases = namingStrategy.getTestCases()
+        assertEquals(1, testCases.size)
+        assertEquals("test_0_QUERY_on_add_returns_empty", testCases[0].name)
+    }
+
+    @Test
+    fun testQueryOnAddCausesInternalServerError() {
+        val eIndividual = getEvaluatedIndividualWithFaults(GQMethodType.QUERY, singletonList(DetectedFault(FaultCategory.HTTP_STATUS_500, "items")))
+        val languageConventionFormatter = LanguageConventionFormatter(OutputFormat.PYTHON_UNITTEST)
+
+        val solution = Solution(singletonList(eIndividual), "suitePrefix", "suiteSuffix", Termination.NONE, emptyList(), emptyList())
+
+        val namingStrategy = GraphQLActionTestCaseNamingStrategy(solution, languageConventionFormatter)
+
+        val testCases = namingStrategy.getTestCases()
+        assertEquals(1, testCases.size)
+        assertEquals("test_0_QUERY_on_add_causes500_internalServerError", testCases[0].name)
+    }
+
+    private fun getEvaluatedIndividualWith(query: GQMethodType): EvaluatedIndividual<GraphQLIndividual> {
+        return getEvaluatedIndividualWithFaults(query, emptyList())
+    }
+
+    private fun getEvaluatedIndividualWithFaults(query: GQMethodType, faults: List<DetectedFault>): EvaluatedIndividual<GraphQLIndividual> {
+        val sampleType = SampleType.RANDOM
+        val op = OptionalGene("foo", StringGene("foo", "foo\""))
+        val param = GQInputParam("foo", op)
+        val action = GraphQLAction("Mutation:add", "add", query, mutableListOf(param))
+
+        val actions = mutableListOf<EnterpriseActionGroup<*>>()
+        actions.add(EnterpriseActionGroup(mutableListOf(action),GraphQLAction::class.java))
+        val individual = GraphQLIndividual(sampleType, actions)
+        TestUtils.doInitializeIndividualForTesting(individual)
+
+        val fitnessVal = FitnessValue(0.0)
+        val result = GraphQlCallResult(action.getLocalId())
+        faults.forEach { fault -> result.addFault(fault) }
+        val results = listOf(result)
+        return EvaluatedIndividual<GraphQLIndividual>(fitnessVal, individual, results)
+    }
+}

--- a/core/src/test/kotlin/org/evomaster/core/output/naming/RPCActionNamingStrategyTest.kt
+++ b/core/src/test/kotlin/org/evomaster/core/output/naming/RPCActionNamingStrategyTest.kt
@@ -1,0 +1,48 @@
+package org.evomaster.core.output.naming
+
+import org.evomaster.core.output.EvaluatedIndividualBuilder
+import org.evomaster.core.output.OutputFormat
+import org.evomaster.core.output.Termination
+import org.evomaster.core.search.Solution
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+
+class RPCActionNamingStrategyTest {
+
+    @Test
+    fun testFakeRpcCallAsInterfaceIdAndId() {
+        val outputFormat = OutputFormat.KOTLIN_JUNIT_5
+        val languageConventionFormatter = LanguageConventionFormatter(outputFormat)
+        val solution = getSolution(outputFormat)
+
+        val namingStrategy = RPCActionTestCaseNamingStrategy(solution, languageConventionFormatter)
+
+        val testCases = namingStrategy.getTestCases()
+        assertEquals(1, testCases.size)
+        assertEquals("test_0_fakerpccallFakerpccall_4ReturnsSuccess", testCases[0].name)
+    }
+
+    private fun getSolution(outputFormat: OutputFormat): Solution<*> {
+        val expectedJson = 5
+
+        return Solution(
+            mutableListOf(
+                //build fake rpc individual in order to test its generated tests
+                EvaluatedIndividualBuilder.buildEvaluatedRPCIndividual(
+                    actions = EvaluatedIndividualBuilder.buildFakeRPCAction(expectedJson),
+                    externalServicesActions = (0 until expectedJson).map {
+                        EvaluatedIndividualBuilder.buildFakeDbExternalServiceAction(1).plus(EvaluatedIndividualBuilder.buildFakeRPCExternalServiceAction(1))
+                    }.toMutableList(),
+
+                    format = outputFormat
+                )
+            ),
+            "suitePrefix",
+            "suiteSuffix",
+            Termination.NONE,
+            listOf(),
+            listOf()
+        )
+    }
+}

--- a/core/src/test/kotlin/org/evomaster/core/output/naming/RPCActionNamingStrategyTest.kt
+++ b/core/src/test/kotlin/org/evomaster/core/output/naming/RPCActionNamingStrategyTest.kt
@@ -20,7 +20,7 @@ class RPCActionNamingStrategyTest {
 
         val testCases = namingStrategy.getTestCases()
         assertEquals(1, testCases.size)
-        assertEquals("test_0_fakerpccallFakerpccall_4ReturnsSuccess", testCases[0].name)
+        assertEquals("test_0_fakerpccallOnFunction_4ReturnsSuccess", testCases[0].name)
     }
 
     private fun getSolution(outputFormat: OutputFormat): Solution<*> {
@@ -30,7 +30,7 @@ class RPCActionNamingStrategyTest {
             mutableListOf(
                 //build fake rpc individual in order to test its generated tests
                 EvaluatedIndividualBuilder.buildEvaluatedRPCIndividual(
-                    actions = EvaluatedIndividualBuilder.buildFakeRPCAction(expectedJson),
+                    actions = EvaluatedIndividualBuilder.buildFakeRPCAction(expectedJson, "FakeRPCCall:function"),
                     externalServicesActions = (0 until expectedJson).map {
                         EvaluatedIndividualBuilder.buildFakeDbExternalServiceAction(1).plus(EvaluatedIndividualBuilder.buildFakeRPCExternalServiceAction(1))
                     }.toMutableList(),

--- a/core/src/test/kotlin/org/evomaster/core/output/naming/RestActionNamingStrategyTest.kt
+++ b/core/src/test/kotlin/org/evomaster/core/output/naming/RestActionNamingStrategyTest.kt
@@ -15,7 +15,7 @@ import org.junit.jupiter.api.Test
 import java.util.Collections.singletonList
 
 
-class ActionNamingStrategyTest {
+class RestActionNamingStrategyTest {
 
     @Test
     fun testGetOnRootPathIsIncludedInName() {
@@ -43,6 +43,36 @@ class ActionNamingStrategyTest {
         val testCases = namingStrategy.getTestCases()
         assertEquals(1, testCases.size)
         assertEquals("test_0_GET_on_items_returns_200", testCases[0].name)
+    }
+
+    @Test
+    fun testTwoDifferentIndividualsGetDifferentNames() {
+        val rootIndividual = getEvaluatedIndividualWith("/")
+        val itemsIndividual = getEvaluatedIndividualWith("/items")
+        val languageConventionFormatter = LanguageConventionFormatter(OutputFormat.PYTHON_UNITTEST)
+
+        val solution = Solution(mutableListOf(rootIndividual, itemsIndividual), "suitePrefix", "suiteSuffix", Termination.NONE, emptyList(), emptyList())
+
+        val namingStrategy = RestActionTestCaseNamingStrategy(solution, languageConventionFormatter)
+
+        val testCases = namingStrategy.getTestCases()
+        assertEquals(2, testCases.size)
+        assertEquals("test_0_GET_on_root_returns_200", testCases[0].name)
+        assertEquals("test_1_GET_on_items_returns_200", testCases[1].name)
+    }
+
+    @Test
+    fun testGetOnItemReturnsSingularPathInName() {
+        val eIndividual = getEvaluatedIndividualWith("/items/{itemId}")
+        val languageConventionFormatter = LanguageConventionFormatter(OutputFormat.PYTHON_UNITTEST)
+
+        val solution = Solution(singletonList(eIndividual), "suitePrefix", "suiteSuffix", Termination.NONE, emptyList(), emptyList())
+
+        val namingStrategy = RestActionTestCaseNamingStrategy(solution, languageConventionFormatter)
+
+        val testCases = namingStrategy.getTestCases()
+        assertEquals(1, testCases.size)
+        assertEquals("test_0_GET_on_item_returns_200", testCases[0].name)
     }
 
     @Test


### PR DESCRIPTION
- Web test cases are named with the numbered naming strategy
- Created action based naming strategy for GraphQL and RPC
- Unit tests for both cases
- Global `nameTokens` var was concatenating test case names as new ones were created (added [testTwoDifferentIndividualsGetDifferentNames](https://github.com/WebFuzzing/EvoMaster/blob/40d4bb3539796728db3d616b3d0fe4c39a6bf5e7/core/src/test/kotlin/org/evomaster/core/output/naming/RestActionNamingStrategyTest.kt#L49) for this)
- Refactor of `GraphQLFitness`, moving `hasErrors` to `GraphQlCallResult` and adding `hasNonEmptyData` as well