### PR TITLE
RPC tests throwing exceptions only include simple class name of exception in test case name. Fixed camelCase for keywords that had capitals in the middle

### DIFF
--- a/core/src/main/kotlin/org/evomaster/core/output/naming/ActionTestCaseNamingStrategy.kt
+++ b/core/src/main/kotlin/org/evomaster/core/output/naming/ActionTestCaseNamingStrategy.kt
@@ -27,7 +27,7 @@ abstract class ActionTestCaseNamingStrategy(
     protected val using = "using"
     protected val sql = "sql"
     protected val mongo = "mongo"
-    protected val wiremock = "wiremock"
+    protected val wiremock = "wireMock"
 
     protected fun formatName(nameTokens: List<String>): String {
         return "_${languageConventionFormatter.formatName(nameTokens)}"

--- a/core/src/main/kotlin/org/evomaster/core/output/naming/LanguageConventionFormatter.kt
+++ b/core/src/main/kotlin/org/evomaster/core/output/naming/LanguageConventionFormatter.kt
@@ -26,6 +26,11 @@ class LanguageConventionFormatter(
 
     }
 
+    /*  
+        Using replaceFirstChar instead of StringUtils.capitalization, since the latter would lowercase the whole string but the first char.
+        This caused exceptions and other words with capitals in the middle to be lowercased, returning strings like: Statusruntimeexception
+        which do not favour readability.
+     */ 
     private fun formatCamelCase(testKeywords: List<String>): String {
         return testKeywords.joinToString("") { testToken -> testToken.replaceFirstChar { if (it.isLowerCase()) it.titlecase(ENGLISH) else it.toString() } }.decapitalize()
     }

--- a/core/src/main/kotlin/org/evomaster/core/output/naming/LanguageConventionFormatter.kt
+++ b/core/src/main/kotlin/org/evomaster/core/output/naming/LanguageConventionFormatter.kt
@@ -2,6 +2,7 @@ package org.evomaster.core.output.naming
 
 import org.evomaster.core.output.OutputFormat
 import org.evomaster.core.utils.StringUtils.capitalization
+import java.util.Locale.ENGLISH
 
 /**
  * Different programming languages have different conventions and style when defining variable names and other programming structures.
@@ -26,7 +27,7 @@ class LanguageConventionFormatter(
     }
 
     private fun formatCamelCase(testKeywords: List<String>): String {
-        return testKeywords.joinToString("") { capitalization(it) }.decapitalize()
+        return testKeywords.joinToString("") { testToken -> testToken.replaceFirstChar { if (it.isLowerCase()) it.titlecase(ENGLISH) else it.toString() } }.decapitalize()
     }
 
     private fun formatSnakeCase(testKeywords: List<String>): String {

--- a/core/src/main/kotlin/org/evomaster/core/output/naming/RPCActionTestCaseNamingStrategy.kt
+++ b/core/src/main/kotlin/org/evomaster/core/output/naming/RPCActionTestCaseNamingStrategy.kt
@@ -6,6 +6,7 @@ import org.evomaster.core.problem.rpc.RPCCallResult
 import org.evomaster.core.search.EvaluatedIndividual
 import org.evomaster.core.search.Solution
 import org.evomaster.core.search.action.EvaluatedAction
+import org.evomaster.core.utils.StringUtils
 
 open class RPCActionTestCaseNamingStrategy(
     solution: Solution<*>,
@@ -28,7 +29,8 @@ open class RPCActionTestCaseNamingStrategy(
         val result = evaluatedAction.result as RPCCallResult
         if (result.hasPotentialFault()) {
             nameTokens.add(throws)
-            nameTokens.add(TestWriterUtils.safeVariableName(result.getExceptionInfo()))
+            val thrownException = StringUtils.extractSimpleClass(result.getExceptionTypeName()?: "")
+            nameTokens.add(TestWriterUtils.safeVariableName(thrownException))
         } else {
             nameTokens.add(returns)
             nameTokens.add(when {

--- a/core/src/main/kotlin/org/evomaster/core/output/naming/RestActionTestCaseNamingStrategy.kt
+++ b/core/src/main/kotlin/org/evomaster/core/output/naming/RestActionTestCaseNamingStrategy.kt
@@ -19,7 +19,7 @@ open class RestActionTestCaseNamingStrategy(
         val evaluatedAction = individual.evaluatedMainActions().last()
         val action = evaluatedAction.action as RestCallAction
 
-        nameTokens.add(action.verb.toString())
+        nameTokens.add(action.verb.toString().lowercase())
         nameTokens.add(on)
         nameTokens.add(getPath(action.path.nameQualifier))
         addResult(individual, nameTokens)

--- a/core/src/main/kotlin/org/evomaster/core/problem/rpc/RPCCallAction.kt
+++ b/core/src/main/kotlin/org/evomaster/core/problem/rpc/RPCCallAction.kt
@@ -6,6 +6,7 @@ import org.evomaster.core.problem.rpc.auth.RPCAuthenticationInfo
 import org.evomaster.core.problem.rpc.auth.RPCNoAuth
 import org.evomaster.core.problem.rpc.param.RPCParam
 import org.evomaster.core.search.gene.Gene
+import org.evomaster.core.utils.StringUtils
 
 /**
  * a RPC call
@@ -61,15 +62,7 @@ open class RPCCallAction(
      * @return the simple class name of a Java or Kotlin class representing the service
      */
     fun getSimpleClassName(): String {
-        return extractSimpleClass(id.split(":")[0])
-    }
-
-    private fun extractSimpleClass(fullyQualifiedName: String) : String {
-        if (fullyQualifiedName.isNullOrEmpty()) return ""
-
-        // Replace $ with . and then split by . to handle inner classes
-        val parts = fullyQualifiedName.replace('$', '.').split(".")
-        return parts.last()
+        return StringUtils.extractSimpleClass(id.split(":")[0])
     }
 
     /**

--- a/core/src/main/kotlin/org/evomaster/core/utils/StringUtils.kt
+++ b/core/src/main/kotlin/org/evomaster/core/utils/StringUtils.kt
@@ -4,12 +4,27 @@ import java.util.*
 
 object StringUtils {
 
-        fun capitalization(word: String) : String{
-            if(word.isEmpty()){
-                return word
-            }
-
-            return word.substring(0, 1).uppercase(Locale.getDefault()) +
-                    word.substring(1).lowercase(Locale.getDefault())
+    fun capitalization(word: String) : String{
+        if(word.isEmpty()){
+            return word
         }
+
+        return word.substring(0, 1).uppercase(Locale.getDefault()) +
+                word.substring(1).lowercase(Locale.getDefault())
+    }
+
+    /**
+     * A function for extracting the Simple Class Name from a class string. Given an inner class in the
+     * OuterClass$InnerClass format, it will return the InnerClass value
+     *
+     * @param fullyQualifiedName of the class to extract
+     * @return the simple class name string
+     */
+    fun extractSimpleClass(fullyQualifiedName: String) : String {
+        if (fullyQualifiedName.isNullOrEmpty()) return ""
+
+        // Replace $ with . and then split by . to handle inner classes
+        val parts = fullyQualifiedName.replace('$', '.').split(".")
+        return parts.last()
+    }
 }

--- a/core/src/test/kotlin/org/evomaster/core/output/naming/LanguageConventionFormatterTest.kt
+++ b/core/src/test/kotlin/org/evomaster/core/output/naming/LanguageConventionFormatterTest.kt
@@ -8,7 +8,7 @@ class LanguageConventionFormatterTest {
 
     @Test
     fun testFormatToCamelCase() {
-        val testKeywords = listOf("GET", "on", "root", "returns", "200")
+        val testKeywords = listOf("get", "on", "root", "returns", "200")
         val languageConventionFormatter = LanguageConventionFormatter(OutputFormat.JAVA_JUNIT_4)
 
         assertEquals("getOnRootReturns200", languageConventionFormatter.formatName(testKeywords))

--- a/core/src/test/kotlin/org/evomaster/core/output/naming/RPCActionNamingStrategyTest.kt
+++ b/core/src/test/kotlin/org/evomaster/core/output/naming/RPCActionNamingStrategyTest.kt
@@ -1,8 +1,12 @@
 package org.evomaster.core.output.naming
 
+import org.evomaster.client.java.controller.api.dto.problem.rpc.RPCExceptionInfoDto
+import org.evomaster.client.java.controller.api.dto.problem.rpc.exception.RPCExceptionType
 import org.evomaster.core.output.EvaluatedIndividualBuilder
 import org.evomaster.core.output.OutputFormat
 import org.evomaster.core.output.Termination
+import org.evomaster.core.problem.rpc.RPCCallResult
+import org.evomaster.core.search.EvaluatedIndividual
 import org.evomaster.core.search.Solution
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
@@ -20,29 +24,57 @@ class RPCActionNamingStrategyTest {
 
         val testCases = namingStrategy.getTestCases()
         assertEquals(1, testCases.size)
-        assertEquals("test_0_fakerpccallOnFunction_4ReturnsSuccess", testCases[0].name)
+        assertEquals("test_0_fakeRPCCallOnFunction_4ReturnsSuccess", testCases[0].name)
     }
 
-    private fun getSolution(outputFormat: OutputFormat): Solution<*> {
-        val expectedJson = 5
+    @Test
+    fun testFakeRpcCallWithException() {
+        val outputFormat = OutputFormat.KOTLIN_JUNIT_5
+        val languageConventionFormatter = LanguageConventionFormatter(outputFormat)
+        val solution = getSolution(outputFormat, true)
 
+        val namingStrategy = RPCActionTestCaseNamingStrategy(solution, languageConventionFormatter)
+
+        val testCases = namingStrategy.getTestCases()
+        assertEquals(1, testCases.size)
+        assertEquals("test_0_fakeRPCCallOnFunction_4ThrowsRuntimeException", testCases[0].name)
+    }
+
+    private fun getSolution(outputFormat: OutputFormat, throwsException: Boolean = false): Solution<*> {
         return Solution(
-            mutableListOf(
-                //build fake rpc individual in order to test its generated tests
-                EvaluatedIndividualBuilder.buildEvaluatedRPCIndividual(
-                    actions = EvaluatedIndividualBuilder.buildFakeRPCAction(expectedJson, "FakeRPCCall:function"),
-                    externalServicesActions = (0 until expectedJson).map {
-                        EvaluatedIndividualBuilder.buildFakeDbExternalServiceAction(1).plus(EvaluatedIndividualBuilder.buildFakeRPCExternalServiceAction(1))
-                    }.toMutableList(),
-
-                    format = outputFormat
-                )
-            ),
+            mutableListOf(getEvaluatedIndividual(outputFormat, throwsException)),
             "suitePrefix",
             "suiteSuffix",
             Termination.NONE,
             listOf(),
             listOf()
         )
+    }
+
+    private fun getEvaluatedIndividual(outputFormat: OutputFormat, throwsException: Boolean): EvaluatedIndividual<*> {
+        val expectedJson = 5
+
+        //build fake rpc individual in order to test its generated tests
+        val evaluatedIndividual = EvaluatedIndividualBuilder.buildEvaluatedRPCIndividual(
+            actions = EvaluatedIndividualBuilder.buildFakeRPCAction(expectedJson, "FakeRPCCall:function"),
+            externalServicesActions = (0 until expectedJson).map {
+                EvaluatedIndividualBuilder.buildFakeDbExternalServiceAction(1).plus(EvaluatedIndividualBuilder.buildFakeRPCExternalServiceAction(1))
+            }.toMutableList(),
+
+            format = outputFormat
+        )
+        if (throwsException) {
+            (evaluatedIndividual.evaluatedMainActions().last().result as RPCCallResult).setRPCException(getExceptionDto())
+        }
+        return evaluatedIndividual
+    }
+
+    private fun getExceptionDto(): RPCExceptionInfoDto {
+        val eDto = RPCExceptionInfoDto()
+        eDto.exceptionName = "java.lang.RuntimeException"
+        eDto.type = RPCExceptionType.UNEXPECTED_EXCEPTION
+        eDto.importanceLevel = 0
+        eDto.isCauseOfUndeclaredThrowable = true
+        return eDto
     }
 }

--- a/core/src/test/kotlin/org/evomaster/core/output/naming/RestActionNamingStrategyTest.kt
+++ b/core/src/test/kotlin/org/evomaster/core/output/naming/RestActionNamingStrategyTest.kt
@@ -50,7 +50,7 @@ class RestActionNamingStrategyTest {
 
         val testCases = namingStrategy.getTestCases()
         assertEquals(1, testCases.size)
-        assertEquals("test_0_GET_on_root_returns_empty", testCases[0].name)
+        assertEquals("test_0_get_on_root_returns_empty", testCases[0].name)
     }
 
     @Test
@@ -63,7 +63,7 @@ class RestActionNamingStrategyTest {
 
         val testCases = namingStrategy.getTestCases()
         assertEquals(1, testCases.size)
-        assertEquals("test_0_GET_on_items_returns_empty", testCases[0].name)
+        assertEquals("test_0_get_on_items_returns_empty", testCases[0].name)
     }
 
     @Test
@@ -79,8 +79,8 @@ class RestActionNamingStrategyTest {
 
         val testCases = namingStrategy.getTestCases()
         assertEquals(2, testCases.size)
-        assertEquals("test_0_GET_on_root_returns_empty", testCases[0].name)
-        assertEquals("test_1_GET_on_items_returns_empty", testCases[1].name)
+        assertEquals("test_0_get_on_root_returns_empty", testCases[0].name)
+        assertEquals("test_1_get_on_items_returns_empty", testCases[1].name)
     }
 
     @Test
@@ -93,7 +93,7 @@ class RestActionNamingStrategyTest {
 
         val testCases = namingStrategy.getTestCases()
         assertEquals(1, testCases.size)
-        assertEquals("test_0_GET_on_item_returns_empty", testCases[0].name)
+        assertEquals("test_0_get_on_item_returns_empty", testCases[0].name)
     }
 
     @Test
@@ -106,7 +106,7 @@ class RestActionNamingStrategyTest {
 
         val testCases = namingStrategy.getTestCases()
         assertEquals(1, testCases.size)
-        assertEquals("test_0_GET_on_items_returns_content", testCases[0].name)
+        assertEquals("test_0_get_on_items_returns_content", testCases[0].name)
     }
 
     @Test
@@ -119,7 +119,7 @@ class RestActionNamingStrategyTest {
 
         val testCases = namingStrategy.getTestCases()
         assertEquals(1, testCases.size)
-        assertEquals("test_0_GET_on_items_returns_empty_list", testCases[0].name)
+        assertEquals("test_0_get_on_items_returns_empty_list", testCases[0].name)
     }
 
     @Test
@@ -132,7 +132,7 @@ class RestActionNamingStrategyTest {
 
         val testCases = namingStrategy.getTestCases()
         assertEquals(1, testCases.size)
-        assertEquals("test_0_GET_on_items_returns_1_element", testCases[0].name)
+        assertEquals("test_0_get_on_items_returns_1_element", testCases[0].name)
     }
 
     @Test
@@ -145,7 +145,7 @@ class RestActionNamingStrategyTest {
 
         val testCases = namingStrategy.getTestCases()
         assertEquals(1, testCases.size)
-        assertEquals("test_0_GET_on_items_returns_3_elements", testCases[0].name)
+        assertEquals("test_0_get_on_items_returns_3_elements", testCases[0].name)
     }
 
     @Test
@@ -158,7 +158,7 @@ class RestActionNamingStrategyTest {
 
         val testCases = namingStrategy.getTestCases()
         assertEquals(1, testCases.size)
-        assertEquals("test_0_GET_on_items_returns_empty_object", testCases[0].name)
+        assertEquals("test_0_get_on_items_returns_empty_object", testCases[0].name)
     }
 
     @Test
@@ -171,7 +171,7 @@ class RestActionNamingStrategyTest {
 
         val testCases = namingStrategy.getTestCases()
         assertEquals(1, testCases.size)
-        assertEquals("test_0_GET_on_items_returns_object", testCases[0].name)
+        assertEquals("test_0_get_on_items_returns_object", testCases[0].name)
     }
 
     @Test
@@ -184,7 +184,7 @@ class RestActionNamingStrategyTest {
 
         val testCases = namingStrategy.getTestCases()
         assertEquals(1, testCases.size)
-        assertEquals("test_0_GET_on_item_returns_string", testCases[0].name)
+        assertEquals("test_0_get_on_item_returns_string", testCases[0].name)
     }
 
     @Test
@@ -197,7 +197,7 @@ class RestActionNamingStrategyTest {
 
         val testCases = namingStrategy.getTestCases()
         assertEquals(1, testCases.size)
-        assertEquals("test_0_GET_on_item_returns_401", testCases[0].name)
+        assertEquals("test_0_get_on_item_returns_401", testCases[0].name)
     }
 
     @Test
@@ -210,7 +210,7 @@ class RestActionNamingStrategyTest {
 
         val testCases = namingStrategy.getTestCases()
         assertEquals(1, testCases.size)
-        assertEquals("test_0_GET_on_items_causes500_internalServerError", testCases[0].name)
+        assertEquals("test_0_get_on_items_causes500_internalServerError", testCases[0].name)
     }
 
     @Test
@@ -224,7 +224,7 @@ class RestActionNamingStrategyTest {
 
         val testCases = namingStrategy.getTestCases()
         assertEquals(1, testCases.size)
-        assertEquals("test_0_GET_on_items_showsFaults_100_102_301", testCases[0].name)
+        assertEquals("test_0_get_on_items_showsFaults_100_102_301", testCases[0].name)
     }
 
     @Test
@@ -263,7 +263,7 @@ class RestActionNamingStrategyTest {
 
         val testCases = namingStrategy.getTestCases()
         assertEquals(1, testCases.size)
-        assertEquals("test_0_putOnItemsReturns201UsingWiremock", testCases[0].name)
+        assertEquals("test_0_putOnItemsReturns201UsingWireMock", testCases[0].name)
     }
 
     @Test
@@ -276,7 +276,7 @@ class RestActionNamingStrategyTest {
 
         val testCases = namingStrategy.getTestCases()
         assertEquals(1, testCases.size)
-        assertEquals("test_0_postOnItemsReturns200UsingSqlWiremock", testCases[0].name)
+        assertEquals("test_0_postOnItemsReturns200UsingSqlWireMock", testCases[0].name)
     }
 
     private fun getEvaluatedIndividualWith(restAction: RestCallAction): EvaluatedIndividual<RestIndividual> {


### PR DESCRIPTION
# What's included
- RPC tests throwing exceptions only include simple class name of exception in test case name
- Fixed camelCase for keywords that had capital letters in the middle, such as exception names
- `replaceFirstChar` approach is suggested by the Kotlin language itself