### PR TITLE
Phg/query params disamb

### DIFF
--- a/core/src/main/kotlin/org/evomaster/core/output/naming/ActionTestCaseNamingStrategy.kt
+++ b/core/src/main/kotlin/org/evomaster/core/output/naming/ActionTestCaseNamingStrategy.kt
@@ -28,6 +28,9 @@ abstract class ActionTestCaseNamingStrategy(
     protected val sql = "sql"
     protected val mongo = "mongo"
     protected val wiremock = "wireMock"
+    protected val with = "with"
+    protected val param = "Param"
+    protected val queryParam = "query$param"
 
     protected fun formatName(nameTokens: List<String>): String {
         return "_${languageConventionFormatter.formatName(nameTokens)}"

--- a/core/src/main/kotlin/org/evomaster/core/output/naming/GraphQLActionTestCaseNamingStrategy.kt
+++ b/core/src/main/kotlin/org/evomaster/core/output/naming/GraphQLActionTestCaseNamingStrategy.kt
@@ -25,7 +25,8 @@ open class GraphQLActionTestCaseNamingStrategy(
         return formatName(nameTokens)
     }
 
-    override fun resolveAmbiguities(duplicatedIndividuals: MutableSet<EvaluatedIndividual<*>>): Map<EvaluatedIndividual<*>, String> {
+//    override fun resolveAmbiguities(duplicatedIndividuals: MutableSet<EvaluatedIndividual<*>>): Map<EvaluatedIndividual<*>, String> {
+    override fun resolveAmbiguities(duplicatedIndividuals: Set<EvaluatedIndividual<*>>): Map<EvaluatedIndividual<*>, String> {
         // TODO do nothing at the moment. This will be completed with the experimental params disambiguation method
         return emptyMap()
     }

--- a/core/src/main/kotlin/org/evomaster/core/output/naming/GraphQLActionTestCaseNamingStrategy.kt
+++ b/core/src/main/kotlin/org/evomaster/core/output/naming/GraphQLActionTestCaseNamingStrategy.kt
@@ -25,7 +25,6 @@ open class GraphQLActionTestCaseNamingStrategy(
         return formatName(nameTokens)
     }
 
-//    override fun resolveAmbiguities(duplicatedIndividuals: MutableSet<EvaluatedIndividual<*>>): Map<EvaluatedIndividual<*>, String> {
     override fun resolveAmbiguities(duplicatedIndividuals: Set<EvaluatedIndividual<*>>): Map<EvaluatedIndividual<*>, String> {
         // TODO do nothing at the moment. This will be completed with the experimental params disambiguation method
         return emptyMap()

--- a/core/src/main/kotlin/org/evomaster/core/output/naming/NumberedTestCaseNamingStrategy.kt
+++ b/core/src/main/kotlin/org/evomaster/core/output/naming/NumberedTestCaseNamingStrategy.kt
@@ -26,7 +26,8 @@ open class NumberedTestCaseNamingStrategy(
         return ""
     }
 
-    override fun resolveAmbiguities(duplicatedIndividuals: MutableSet<EvaluatedIndividual<*>>): Map<EvaluatedIndividual<*>, String> {
+//    override fun resolveAmbiguities(duplicatedIndividuals: MutableSet<EvaluatedIndividual<*>>): Map<EvaluatedIndividual<*>, String> {
+    override fun resolveAmbiguities(duplicatedIndividuals: Set<EvaluatedIndividual<*>>): Map<EvaluatedIndividual<*>, String> {
         // do nothing, plain numbered strategy will never have duplicate names
         return emptyMap()
     }
@@ -51,12 +52,18 @@ open class NumberedTestCaseNamingStrategy(
             var previousSize: Int
             do {
                 previousSize = it.size
-                individualToName.putAll(resolveAmbiguities(it))
+                val solvedAmbiguities = resolveAmbiguities(it)
+                individualToName.putAll(solvedAmbiguities)
+                removeSolvedDuplicates(it, solvedAmbiguities.keys)
             } while(previousSize != it.size)
         }
 
         var counter = 0
         return individualToName.map { entry -> TestCase(entry.key, concatName(counter++, entry.value)) }
+    }
+
+    private fun removeSolvedDuplicates(duplicatedIndividuals: MutableSet<EvaluatedIndividual<*>>, disambiguatedIndividuals: Set<EvaluatedIndividual<*>>) {
+        duplicatedIndividuals.removeAll(disambiguatedIndividuals)
     }
 
     private fun getDuplicateNames(individualToName: Map<EvaluatedIndividual<*>, String>): List<MutableSet<EvaluatedIndividual<*>>> {

--- a/core/src/main/kotlin/org/evomaster/core/output/naming/NumberedTestCaseNamingStrategy.kt
+++ b/core/src/main/kotlin/org/evomaster/core/output/naming/NumberedTestCaseNamingStrategy.kt
@@ -54,8 +54,6 @@ open class NumberedTestCaseNamingStrategy(
                 individualToName.putAll(resolveAmbiguities(it))
             } while(previousSize != it.size)
         }
-//        val dup3 = getDuplicateNames(individualToName)
-//        dup3.forEach { individualToName.putAll(resolveAmbiguities(it)) }
 
         var counter = 0
         return individualToName.map { entry -> TestCase(entry.key, concatName(counter++, entry.value)) }

--- a/core/src/main/kotlin/org/evomaster/core/output/naming/NumberedTestCaseNamingStrategy.kt
+++ b/core/src/main/kotlin/org/evomaster/core/output/naming/NumberedTestCaseNamingStrategy.kt
@@ -47,8 +47,15 @@ open class NumberedTestCaseNamingStrategy(
             individualToName[it] = expandName(it, mutableListOf())
         }
 
-        getDuplicateNames(individualToName)
-            .forEach { individualToName.putAll(resolveAmbiguities(it)) }
+        getDuplicateNames(individualToName).forEach {
+            var previousSize: Int
+            do {
+                previousSize = it.size
+                individualToName.putAll(resolveAmbiguities(it))
+            } while(previousSize != it.size)
+        }
+//        val dup3 = getDuplicateNames(individualToName)
+//        dup3.forEach { individualToName.putAll(resolveAmbiguities(it)) }
 
         var counter = 0
         return individualToName.map { entry -> TestCase(entry.key, concatName(counter++, entry.value)) }

--- a/core/src/main/kotlin/org/evomaster/core/output/naming/NumberedTestCaseNamingStrategy.kt
+++ b/core/src/main/kotlin/org/evomaster/core/output/naming/NumberedTestCaseNamingStrategy.kt
@@ -26,7 +26,6 @@ open class NumberedTestCaseNamingStrategy(
         return ""
     }
 
-//    override fun resolveAmbiguities(duplicatedIndividuals: MutableSet<EvaluatedIndividual<*>>): Map<EvaluatedIndividual<*>, String> {
     override fun resolveAmbiguities(duplicatedIndividuals: Set<EvaluatedIndividual<*>>): Map<EvaluatedIndividual<*>, String> {
         // do nothing, plain numbered strategy will never have duplicate names
         return emptyMap()

--- a/core/src/main/kotlin/org/evomaster/core/output/naming/RPCActionTestCaseNamingStrategy.kt
+++ b/core/src/main/kotlin/org/evomaster/core/output/naming/RPCActionTestCaseNamingStrategy.kt
@@ -26,7 +26,8 @@ open class RPCActionTestCaseNamingStrategy(
         return formatName(nameTokens)
     }
 
-    override fun resolveAmbiguities(duplicatedIndividuals: MutableSet<EvaluatedIndividual<*>>): Map<EvaluatedIndividual<*>, String> {
+//    override fun resolveAmbiguities(duplicatedIndividuals: MutableSet<EvaluatedIndividual<*>>): Map<EvaluatedIndividual<*>, String> {
+    override fun resolveAmbiguities(duplicatedIndividuals: Set<EvaluatedIndividual<*>>): Map<EvaluatedIndividual<*>, String> {
         // TODO do nothing at the moment. This will be completed with the experimental params disambiguation method
         return emptyMap()
     }

--- a/core/src/main/kotlin/org/evomaster/core/output/naming/RPCActionTestCaseNamingStrategy.kt
+++ b/core/src/main/kotlin/org/evomaster/core/output/naming/RPCActionTestCaseNamingStrategy.kt
@@ -26,7 +26,6 @@ open class RPCActionTestCaseNamingStrategy(
         return formatName(nameTokens)
     }
 
-//    override fun resolveAmbiguities(duplicatedIndividuals: MutableSet<EvaluatedIndividual<*>>): Map<EvaluatedIndividual<*>, String> {
     override fun resolveAmbiguities(duplicatedIndividuals: Set<EvaluatedIndividual<*>>): Map<EvaluatedIndividual<*>, String> {
         // TODO do nothing at the moment. This will be completed with the experimental params disambiguation method
         return emptyMap()

--- a/core/src/main/kotlin/org/evomaster/core/output/naming/RestActionTestCaseNamingStrategy.kt
+++ b/core/src/main/kotlin/org/evomaster/core/output/naming/RestActionTestCaseNamingStrategy.kt
@@ -45,8 +45,8 @@ open class RestActionTestCaseNamingStrategy(
     }
 
     /**
-     * In REST Individuals, ambiguities will be resolved with the path solver.
-     * UriParams and QueryParams solvers will be left for experimentalPurposes.
+     * In REST Individuals, ambiguities will be resolved with the path and queryParams solvers.
+     * UriParams solver will be left for experimentalPurposes, as well as using the query param values for naming.
      *
      * Whenever an ambiguity is solved, then it should remove that test from the cycle. There is no need to execute the
      * following solvers.
@@ -110,7 +110,7 @@ open class RestActionTestCaseNamingStrategy(
     }
 
     /*
-     * If any test uses query prams, then add withQueryParam(s) after the path to them to make them differ.
+     * If any test uses query params, then add withQueryParam(s) after the path to them to make them differ.
      * The filter call ensures that we are only performing this disambiguation when there's only one individual that
      * differs and the list of query params is not empty.
      */

--- a/core/src/main/kotlin/org/evomaster/core/output/naming/RestActionTestCaseNamingStrategy.kt
+++ b/core/src/main/kotlin/org/evomaster/core/output/naming/RestActionTestCaseNamingStrategy.kt
@@ -53,7 +53,7 @@ open class RestActionTestCaseNamingStrategy(
      */
     override fun resolveAmbiguities(duplicatedIndividuals: Set<EvaluatedIndividual<*>>): Map<EvaluatedIndividual<*>, String> {
         val solvedAmbiguities = mutableMapOf<EvaluatedIndividual<*>, String>()
-        var workingCopy = duplicatedIndividuals.toMutableSet()
+        val workingCopy = duplicatedIndividuals.toMutableSet()
 
         val pathDisambiguatedIndividuals = solvePathAmbiguities(workingCopy)
         solvedAmbiguities.putAll(pathDisambiguatedIndividuals)

--- a/core/src/main/kotlin/org/evomaster/core/output/naming/RestActionTestCaseNamingStrategy.kt
+++ b/core/src/main/kotlin/org/evomaster/core/output/naming/RestActionTestCaseNamingStrategy.kt
@@ -2,7 +2,6 @@ package org.evomaster.core.output.naming
 
 import com.google.gson.Gson
 import com.google.gson.JsonSyntaxException
-import org.evomaster.core.output.TestWriterUtils.safeVariableName
 import org.evomaster.core.problem.rest.HttpVerb
 import org.evomaster.core.problem.rest.RestCallAction
 import org.evomaster.core.problem.rest.RestCallResult

--- a/core/src/main/kotlin/org/evomaster/core/output/naming/TestCaseNamingStrategy.kt
+++ b/core/src/main/kotlin/org/evomaster/core/output/naming/TestCaseNamingStrategy.kt
@@ -39,7 +39,6 @@ abstract class TestCaseNamingStrategy(
      *
      * @return a Map of EvaluatedIndividuals and the disambiguated test case name
      */
-//    protected abstract fun resolveAmbiguities(duplicatedIndividuals: MutableSet<EvaluatedIndividual<*>>): Map<EvaluatedIndividual<*>, String>
     protected abstract fun resolveAmbiguities(duplicatedIndividuals: Set<EvaluatedIndividual<*>>): Map<EvaluatedIndividual<*>, String>
 
 }

--- a/core/src/main/kotlin/org/evomaster/core/output/naming/TestCaseNamingStrategy.kt
+++ b/core/src/main/kotlin/org/evomaster/core/output/naming/TestCaseNamingStrategy.kt
@@ -39,6 +39,7 @@ abstract class TestCaseNamingStrategy(
      *
      * @return a Map of EvaluatedIndividuals and the disambiguated test case name
      */
-    protected abstract fun resolveAmbiguities(duplicatedIndividuals: MutableSet<EvaluatedIndividual<*>>): Map<EvaluatedIndividual<*>, String>
+//    protected abstract fun resolveAmbiguities(duplicatedIndividuals: MutableSet<EvaluatedIndividual<*>>): Map<EvaluatedIndividual<*>, String>
+    protected abstract fun resolveAmbiguities(duplicatedIndividuals: Set<EvaluatedIndividual<*>>): Map<EvaluatedIndividual<*>, String>
 
 }


### PR DESCRIPTION
- Adding an extra layer for test naming differentiation for REST scenarios. It takes into account the presence of query params, but not the values. The latter ones will be added for the experimental features, but setting the grounds here.
- Test disambiguation now takes place until no change has been detected. This will happen since the check runs against the size of `duplicatedIndividuals: MutableSet`, either no more disambiguation takes place (no individuals are removed from the set) or eventually all individuals are disambigauted (the set size is now 0 and the next iteration will have the same size)