### PR TITLE
True boolean query parameters are added to rest test case names experimentation

### DIFF
--- a/core/src/main/kotlin/org/evomaster/core/EMConfig.kt
+++ b/core/src/main/kotlin/org/evomaster/core/EMConfig.kt
@@ -475,10 +475,6 @@ class EMConfig {
             throw ConfigProblemException("Python output is used only for black-box testing")
         }
 
-        if (namingStrategy == NamingStrategy.NUMBERED && nameWithQueryParameters) {
-            throw ConfigProblemException("Test case naming with Query Parameters is only allowed for Action based naming strategy")
-        }
-
         when (stoppingCriterion) {
             StoppingCriterion.TIME -> if (maxEvaluations != defaultMaxEvaluations) {
                 throw ConfigProblemException("Changing number of max actions, but stopping criterion is time")

--- a/core/src/main/kotlin/org/evomaster/core/EMConfig.kt
+++ b/core/src/main/kotlin/org/evomaster/core/EMConfig.kt
@@ -475,6 +475,10 @@ class EMConfig {
             throw ConfigProblemException("Python output is used only for black-box testing")
         }
 
+        if (namingStrategy == NamingStrategy.NUMBERED && nameWithQueryParameters) {
+            throw ConfigProblemException("Test case naming with Query Parameters is only allowed for Action based naming strategy")
+        }
+
         when (stoppingCriterion) {
             StoppingCriterion.TIME -> if (maxEvaluations != defaultMaxEvaluations) {
                 throw ConfigProblemException("Changing number of max actions, but stopping criterion is time")
@@ -2380,6 +2384,11 @@ class EMConfig {
 
     @Cfg("Specify the naming strategy for test cases.")
     var namingStrategy = defaultTestCaseNamingStrategy
+
+    @Experimental
+    @Cfg("Specify if true boolean query parameters are included in the test case name." +
+            " Used for test case naming disambiguation. Only valid for Action based naming strategy.")
+    var nameWithQueryParameters = false
 
 
     @Experimental

--- a/core/src/main/kotlin/org/evomaster/core/output/naming/ActionTestCaseNamingStrategy.kt
+++ b/core/src/main/kotlin/org/evomaster/core/output/naming/ActionTestCaseNamingStrategy.kt
@@ -31,6 +31,7 @@ abstract class ActionTestCaseNamingStrategy(
     protected val with = "with"
     protected val param = "Param"
     protected val queryParam = "query$param"
+    protected val and = "and"
 
     protected fun formatName(nameTokens: List<String>): String {
         return "_${languageConventionFormatter.formatName(nameTokens)}"

--- a/core/src/main/kotlin/org/evomaster/core/output/naming/RestActionTestCaseNamingStrategy.kt
+++ b/core/src/main/kotlin/org/evomaster/core/output/naming/RestActionTestCaseNamingStrategy.kt
@@ -155,12 +155,10 @@ open class RestActionTestCaseNamingStrategy(
 
     private fun addQueryParameterNames(queryParams: List<QueryParam>, result: MutableList<String>) {
         val booleanQueryParams = getBooleanQueryParams(queryParams)
-        if (booleanQueryParams.isNotEmpty()) {
-            booleanQueryParams.forEachIndexed { index, queryParam ->
-                result.add(queryParam.name)
-                if (index != booleanQueryParams.lastIndex) {
-                    result.add(and)
-                }
+        booleanQueryParams.forEachIndexed { index, queryParam ->
+            result.add(queryParam.name)
+            if (index != booleanQueryParams.lastIndex) {
+                result.add(and)
             }
         }
     }

--- a/core/src/main/kotlin/org/evomaster/core/output/naming/TestCaseNamingStrategyFactory.kt
+++ b/core/src/main/kotlin/org/evomaster/core/output/naming/TestCaseNamingStrategyFactory.kt
@@ -11,10 +11,11 @@ import org.slf4j.LoggerFactory
 
 class TestCaseNamingStrategyFactory(
     private val namingStrategy: NamingStrategy,
-    private val languageConventionFormatter: LanguageConventionFormatter
+    private val languageConventionFormatter: LanguageConventionFormatter,
+    private val nameWithQueryParameters: Boolean,
 ) {
 
-    constructor(config: EMConfig): this(config.namingStrategy, LanguageConventionFormatter(config.outputFormat))
+    constructor(config: EMConfig): this(config.namingStrategy, LanguageConventionFormatter(config.outputFormat), config.nameWithQueryParameters)
 
     companion object {
         private val log: Logger = LoggerFactory.getLogger(TestCaseNamingStrategyFactory::class.java)
@@ -31,7 +32,7 @@ class TestCaseNamingStrategyFactory(
     private fun actionBasedNamingStrategy(solution: Solution<*>): NumberedTestCaseNamingStrategy {
         val individuals = solution.individuals
         return when {
-            individuals.any { it.individual is RestIndividual } -> return RestActionTestCaseNamingStrategy(solution, languageConventionFormatter)
+            individuals.any { it.individual is RestIndividual } -> return RestActionTestCaseNamingStrategy(solution, languageConventionFormatter, nameWithQueryParameters)
             individuals.any { it.individual is GraphQLIndividual } -> return GraphQLActionTestCaseNamingStrategy(solution, languageConventionFormatter)
             individuals.any { it.individual is RPCIndividual } -> return RPCActionTestCaseNamingStrategy(solution, languageConventionFormatter)
             individuals.any { it.individual is WebIndividual } -> {

--- a/core/src/test/kotlin/org/evomaster/core/EMConfigTest.kt
+++ b/core/src/test/kotlin/org/evomaster/core/EMConfigTest.kt
@@ -582,7 +582,7 @@ internal class EMConfigTest{
         val parser = EMConfig.getOptionParser()
         val config = EMConfig()
 
-        var options = parser.parse("--outputFormat", "PYTHON_UNITTEST")
+        val options = parser.parse("--outputFormat", "PYTHON_UNITTEST")
         assertThrows(Exception::class.java, {config.updateProperties(options)})
     }
 
@@ -605,6 +605,50 @@ internal class EMConfigTest{
         config.updateProperties(parser.parse())
 
         assertEquals(NamingStrategy.NUMBERED, config.namingStrategy)
+    }
+
+    @Test
+    fun testQueryParamsInTestCaseNamesValidForActionStrategy() {
+        val parser = EMConfig.getOptionParser()
+        val config = EMConfig()
+
+        val options = parser.parse("--namingStrategy", "ACTION", "--nameWithQueryParameters", "true")
+        config.updateProperties(options)
+
+        assertEquals(NamingStrategy.ACTION, config.namingStrategy)
+        assertTrue(config.nameWithQueryParameters)
+    }
+
+    @Test
+    fun testQueryParamsInTestCaseNamesFalseTurnsFeatureOff() {
+        val parser = EMConfig.getOptionParser()
+        val config = EMConfig()
+
+        val options = parser.parse("--namingStrategy", "ACTION", "--nameWithQueryParameters", "false")
+        config.updateProperties(options)
+
+        assertEquals(NamingStrategy.ACTION, config.namingStrategy)
+        assertFalse(config.nameWithQueryParameters)
+    }
+
+    @Test
+    fun testQueryParamsInTestCaseNamesIsNotValidForNumberedStrategy() {
+        val parser = EMConfig.getOptionParser()
+        val config = EMConfig()
+
+        val options = parser.parse("--namingStrategy", "NUMBERED", "--nameWithQueryParameters", "true")
+
+        assertThrows(Exception::class.java, {config.updateProperties(options)})
+    }
+
+    @Test
+    fun testQueryParamsInTestCaseNamesIsOffByDefault() {
+        val parser = EMConfig.getOptionParser()
+        val config = EMConfig()
+
+        config.updateProperties(parser.parse())
+
+        assertFalse(config.nameWithQueryParameters)
     }
 
 }

--- a/core/src/test/kotlin/org/evomaster/core/EMConfigTest.kt
+++ b/core/src/test/kotlin/org/evomaster/core/EMConfigTest.kt
@@ -632,16 +632,6 @@ internal class EMConfigTest{
     }
 
     @Test
-    fun testQueryParamsInTestCaseNamesIsNotValidForNumberedStrategy() {
-        val parser = EMConfig.getOptionParser()
-        val config = EMConfig()
-
-        val options = parser.parse("--namingStrategy", "NUMBERED", "--nameWithQueryParameters", "true")
-
-        assertThrows(Exception::class.java, {config.updateProperties(options)})
-    }
-
-    @Test
     fun testQueryParamsInTestCaseNamesIsOffByDefault() {
         val parser = EMConfig.getOptionParser()
         val config = EMConfig()

--- a/core/src/test/kotlin/org/evomaster/core/output/naming/RestActionNamingStrategyTest.kt
+++ b/core/src/test/kotlin/org/evomaster/core/output/naming/RestActionNamingStrategyTest.kt
@@ -20,6 +20,7 @@ open class RestActionNamingStrategyTest {
     companion object {
         val pythonFormatter = LanguageConventionFormatter(OutputFormat.PYTHON_UNITTEST)
         val javaFormatter = LanguageConventionFormatter(OutputFormat.JAVA_JUNIT_4)
+        const val NO_QUERY_PARAMS_IN_NAME = false
     }
 
     @Test
@@ -29,7 +30,7 @@ open class RestActionNamingStrategyTest {
 
         val solution = Solution(singletonList(eIndividual), "suitePrefix", "suiteSuffix", Termination.NONE, emptyList(), emptyList())
 
-        val namingStrategy = RestActionTestCaseNamingStrategy(solution, pythonFormatter)
+        val namingStrategy = RestActionTestCaseNamingStrategy(solution, pythonFormatter, NO_QUERY_PARAMS_IN_NAME)
 
         val testCases = namingStrategy.getTestCases()
         assertEquals(1, testCases.size)
@@ -42,7 +43,7 @@ open class RestActionNamingStrategyTest {
         val eIndividual = getEvaluatedIndividualWith(restAction)
         val solution = Solution(singletonList(eIndividual), "suitePrefix", "suiteSuffix", Termination.NONE, emptyList(), emptyList())
 
-        val namingStrategy = RestActionTestCaseNamingStrategy(solution, pythonFormatter)
+        val namingStrategy = RestActionTestCaseNamingStrategy(solution, pythonFormatter, NO_QUERY_PARAMS_IN_NAME)
 
         val testCases = namingStrategy.getTestCases()
         assertEquals(1, testCases.size)
@@ -58,7 +59,7 @@ open class RestActionNamingStrategyTest {
         val itemsIndividual = getEvaluatedIndividualWith(itemsAction)
         val solution = Solution(mutableListOf(rootIndividual, itemsIndividual), "suitePrefix", "suiteSuffix", Termination.NONE, emptyList(), emptyList())
 
-        val namingStrategy = RestActionTestCaseNamingStrategy(solution, pythonFormatter)
+        val namingStrategy = RestActionTestCaseNamingStrategy(solution, pythonFormatter, NO_QUERY_PARAMS_IN_NAME)
 
         val testCases = namingStrategy.getTestCases()
         assertEquals(2, testCases.size)
@@ -72,7 +73,7 @@ open class RestActionNamingStrategyTest {
         val eIndividual = getEvaluatedIndividualWith(restAction)
         val solution = Solution(singletonList(eIndividual), "suitePrefix", "suiteSuffix", Termination.NONE, emptyList(), emptyList())
 
-        val namingStrategy = RestActionTestCaseNamingStrategy(solution, pythonFormatter)
+        val namingStrategy = RestActionTestCaseNamingStrategy(solution, pythonFormatter, NO_QUERY_PARAMS_IN_NAME)
 
         val testCases = namingStrategy.getTestCases()
         assertEquals(1, testCases.size)
@@ -85,7 +86,7 @@ open class RestActionNamingStrategyTest {
         val eIndividual = getEvaluatedIndividualWith(restAction, 200, "<tag/>", MediaType.TEXT_XML_TYPE)
         val solution = Solution(singletonList(eIndividual), "suitePrefix", "suiteSuffix", Termination.NONE, emptyList(), emptyList())
 
-        val namingStrategy = RestActionTestCaseNamingStrategy(solution, pythonFormatter)
+        val namingStrategy = RestActionTestCaseNamingStrategy(solution, pythonFormatter, NO_QUERY_PARAMS_IN_NAME)
 
         val testCases = namingStrategy.getTestCases()
         assertEquals(1, testCases.size)
@@ -98,7 +99,7 @@ open class RestActionNamingStrategyTest {
         val eIndividual = getEvaluatedIndividualWith(restAction, 200, "[]", MediaType.APPLICATION_JSON_TYPE)
         val solution = Solution(singletonList(eIndividual), "suitePrefix", "suiteSuffix", Termination.NONE, emptyList(), emptyList())
 
-        val namingStrategy = RestActionTestCaseNamingStrategy(solution, pythonFormatter)
+        val namingStrategy = RestActionTestCaseNamingStrategy(solution, pythonFormatter, NO_QUERY_PARAMS_IN_NAME)
 
         val testCases = namingStrategy.getTestCases()
         assertEquals(1, testCases.size)
@@ -111,7 +112,7 @@ open class RestActionNamingStrategyTest {
         val eIndividual = getEvaluatedIndividualWith(restAction, 200, "[1]", MediaType.APPLICATION_JSON_TYPE)
         val solution = Solution(singletonList(eIndividual), "suitePrefix", "suiteSuffix", Termination.NONE, emptyList(), emptyList())
 
-        val namingStrategy = RestActionTestCaseNamingStrategy(solution, pythonFormatter)
+        val namingStrategy = RestActionTestCaseNamingStrategy(solution, pythonFormatter, NO_QUERY_PARAMS_IN_NAME)
 
         val testCases = namingStrategy.getTestCases()
         assertEquals(1, testCases.size)
@@ -124,7 +125,7 @@ open class RestActionNamingStrategyTest {
         val eIndividual = getEvaluatedIndividualWith(restAction, 200, "[1,2,3]", MediaType.APPLICATION_JSON_TYPE)
         val solution = Solution(singletonList(eIndividual), "suitePrefix", "suiteSuffix", Termination.NONE, emptyList(), emptyList())
 
-        val namingStrategy = RestActionTestCaseNamingStrategy(solution, pythonFormatter)
+        val namingStrategy = RestActionTestCaseNamingStrategy(solution, pythonFormatter, NO_QUERY_PARAMS_IN_NAME)
 
         val testCases = namingStrategy.getTestCases()
         assertEquals(1, testCases.size)
@@ -137,7 +138,7 @@ open class RestActionNamingStrategyTest {
         val eIndividual = getEvaluatedIndividualWith(restAction, 200, "{}", MediaType.APPLICATION_JSON_TYPE)
         val solution = Solution(singletonList(eIndividual), "suitePrefix", "suiteSuffix", Termination.NONE, emptyList(), emptyList())
 
-        val namingStrategy = RestActionTestCaseNamingStrategy(solution, pythonFormatter)
+        val namingStrategy = RestActionTestCaseNamingStrategy(solution, pythonFormatter, NO_QUERY_PARAMS_IN_NAME)
 
         val testCases = namingStrategy.getTestCases()
         assertEquals(1, testCases.size)
@@ -150,7 +151,7 @@ open class RestActionNamingStrategyTest {
         val eIndividual = getEvaluatedIndividualWith(restAction, 200, "{\"key\": \"value\"}", MediaType.APPLICATION_JSON_TYPE)
         val solution = Solution(singletonList(eIndividual), "suitePrefix", "suiteSuffix", Termination.NONE, emptyList(), emptyList())
 
-        val namingStrategy = RestActionTestCaseNamingStrategy(solution, pythonFormatter)
+        val namingStrategy = RestActionTestCaseNamingStrategy(solution, pythonFormatter, NO_QUERY_PARAMS_IN_NAME)
 
         val testCases = namingStrategy.getTestCases()
         assertEquals(1, testCases.size)
@@ -163,7 +164,7 @@ open class RestActionNamingStrategyTest {
         val eIndividual = getEvaluatedIndividualWith(restAction, 200, "\"myItem\"", MediaType.APPLICATION_JSON_TYPE)
         val solution = Solution(singletonList(eIndividual), "suitePrefix", "suiteSuffix", Termination.NONE, emptyList(), emptyList())
 
-        val namingStrategy = RestActionTestCaseNamingStrategy(solution, pythonFormatter)
+        val namingStrategy = RestActionTestCaseNamingStrategy(solution, pythonFormatter, NO_QUERY_PARAMS_IN_NAME)
 
         val testCases = namingStrategy.getTestCases()
         assertEquals(1, testCases.size)
@@ -176,7 +177,7 @@ open class RestActionNamingStrategyTest {
         val eIndividual = getEvaluatedIndividualWith(restAction, 401, "[]", MediaType.APPLICATION_JSON_TYPE)
         val solution = Solution(singletonList(eIndividual), "suitePrefix", "suiteSuffix", Termination.NONE, emptyList(), emptyList())
 
-        val namingStrategy = RestActionTestCaseNamingStrategy(solution, pythonFormatter)
+        val namingStrategy = RestActionTestCaseNamingStrategy(solution, pythonFormatter, NO_QUERY_PARAMS_IN_NAME)
 
         val testCases = namingStrategy.getTestCases()
         assertEquals(1, testCases.size)
@@ -189,7 +190,7 @@ open class RestActionNamingStrategyTest {
         val eIndividual = getEvaluatedIndividualWithFaults(restAction, singletonList(DetectedFault(FaultCategory.HTTP_STATUS_500, "items")), 500)
         val solution = Solution(singletonList(eIndividual), "suitePrefix", "suiteSuffix", Termination.NONE, emptyList(), emptyList())
 
-        val namingStrategy = RestActionTestCaseNamingStrategy(solution, pythonFormatter)
+        val namingStrategy = RestActionTestCaseNamingStrategy(solution, pythonFormatter, NO_QUERY_PARAMS_IN_NAME)
 
         val testCases = namingStrategy.getTestCases()
         assertEquals(1, testCases.size)
@@ -203,7 +204,7 @@ open class RestActionNamingStrategyTest {
         val eIndividual = getEvaluatedIndividualWithFaults(restAction, faults, 500)
         val solution = Solution(singletonList(eIndividual), "suitePrefix", "suiteSuffix", Termination.NONE, emptyList(), emptyList())
 
-        val namingStrategy = RestActionTestCaseNamingStrategy(solution, pythonFormatter)
+        val namingStrategy = RestActionTestCaseNamingStrategy(solution, pythonFormatter, NO_QUERY_PARAMS_IN_NAME)
 
         val testCases = namingStrategy.getTestCases()
         assertEquals(1, testCases.size)
@@ -216,7 +217,7 @@ open class RestActionNamingStrategyTest {
         val eIndividual = getEvaluatedIndividualWith(restAction, true)
         val solution = Solution(singletonList(eIndividual), "suitePrefix", "suiteSuffix", Termination.NONE, emptyList(), emptyList())
 
-        val namingStrategy = RestActionTestCaseNamingStrategy(solution, javaFormatter)
+        val namingStrategy = RestActionTestCaseNamingStrategy(solution, javaFormatter, NO_QUERY_PARAMS_IN_NAME)
 
         val testCases = namingStrategy.getTestCases()
         assertEquals(1, testCases.size)
@@ -229,7 +230,7 @@ open class RestActionNamingStrategyTest {
         val eIndividual = getEvaluatedIndividualWith(restAction, withMongo = true)
         val solution = Solution(singletonList(eIndividual), "suitePrefix", "suiteSuffix", Termination.NONE, emptyList(), emptyList())
 
-        val namingStrategy = RestActionTestCaseNamingStrategy(solution, javaFormatter)
+        val namingStrategy = RestActionTestCaseNamingStrategy(solution, javaFormatter, NO_QUERY_PARAMS_IN_NAME)
 
         val testCases = namingStrategy.getTestCases()
         assertEquals(1, testCases.size)
@@ -242,7 +243,7 @@ open class RestActionNamingStrategyTest {
         val eIndividual = getEvaluatedIndividualWith(restAction, 201, withWireMock = true)
         val solution = Solution(singletonList(eIndividual), "suitePrefix", "suiteSuffix", Termination.NONE, emptyList(), emptyList())
 
-        val namingStrategy = RestActionTestCaseNamingStrategy(solution, javaFormatter)
+        val namingStrategy = RestActionTestCaseNamingStrategy(solution, javaFormatter, NO_QUERY_PARAMS_IN_NAME)
 
         val testCases = namingStrategy.getTestCases()
         assertEquals(1, testCases.size)
@@ -255,7 +256,7 @@ open class RestActionNamingStrategyTest {
         val eIndividual = getEvaluatedIndividualWith(restAction, withSql = true, withWireMock = true)
         val solution = Solution(singletonList(eIndividual), "suitePrefix", "suiteSuffix", Termination.NONE, emptyList(), emptyList())
 
-        val namingStrategy = RestActionTestCaseNamingStrategy(solution, javaFormatter)
+        val namingStrategy = RestActionTestCaseNamingStrategy(solution, javaFormatter, NO_QUERY_PARAMS_IN_NAME)
 
         val testCases = namingStrategy.getTestCases()
         assertEquals(1, testCases.size)

--- a/core/src/test/kotlin/org/evomaster/core/output/naming/TestCaseDisambiguationTest.kt
+++ b/core/src/test/kotlin/org/evomaster/core/output/naming/TestCaseDisambiguationTest.kt
@@ -6,9 +6,13 @@ import org.evomaster.core.output.naming.RestActionTestCaseUtils.getEvaluatedIndi
 import org.evomaster.core.output.naming.RestActionTestCaseUtils.getRestCallAction
 import org.evomaster.core.problem.api.param.Param
 import org.evomaster.core.problem.rest.HttpVerb
+import org.evomaster.core.problem.rest.RestCallAction
+import org.evomaster.core.problem.rest.RestIndividual
 import org.evomaster.core.problem.rest.param.PathParam
 import org.evomaster.core.problem.rest.param.QueryParam
+import org.evomaster.core.search.EvaluatedIndividual
 import org.evomaster.core.search.Solution
+import org.evomaster.core.search.gene.BooleanGene
 import org.evomaster.core.search.gene.optional.CustomMutationRateGene
 import org.evomaster.core.search.gene.string.StringGene
 import org.junit.jupiter.api.Assertions.assertEquals
@@ -19,6 +23,8 @@ class TestCaseDisambiguationTest {
 
     companion object {
         val javaFormatter = LanguageConventionFormatter(OutputFormat.JAVA_JUNIT_4)
+        const val NO_QUERY_PARAMS_IN_NAME = false
+        const val QUERY_PARAMS_IN_NAME = true
     }
 
     @Test
@@ -28,7 +34,7 @@ class TestCaseDisambiguationTest {
 
         val solution = Solution(mutableListOf(funnyPathIndividual, funniestPathIndividual), "suitePrefix", "suiteSuffix", Termination.NONE, emptyList(), emptyList())
 
-        val namingStrategy = RestActionTestCaseNamingStrategy(solution, javaFormatter)
+        val namingStrategy = RestActionTestCaseNamingStrategy(solution, javaFormatter, NO_QUERY_PARAMS_IN_NAME)
 
         val testCases = namingStrategy.getTestCases()
         assertEquals(2, testCases.size)
@@ -45,7 +51,7 @@ class TestCaseDisambiguationTest {
 
         val solution = Solution(mutableListOf(languagesIndividual, statisticsLanguagesIndividual, syntaxLanguagesIndividual), "suitePrefix", "suiteSuffix", Termination.NONE, emptyList(), emptyList())
 
-        val namingStrategy = RestActionTestCaseNamingStrategy(solution, javaFormatter)
+        val namingStrategy = RestActionTestCaseNamingStrategy(solution, javaFormatter, NO_QUERY_PARAMS_IN_NAME)
 
         val testCases = namingStrategy.getTestCases()
         assertEquals(3, testCases.size)
@@ -63,7 +69,7 @@ class TestCaseDisambiguationTest {
 
         val solution = Solution(mutableListOf(languagesIndividual, syntaxLanguagesIndividual, syntaxLanguagesIndividual2), "suitePrefix", "suiteSuffix", Termination.NONE, emptyList(), emptyList())
 
-        val namingStrategy = RestActionTestCaseNamingStrategy(solution, javaFormatter)
+        val namingStrategy = RestActionTestCaseNamingStrategy(solution, javaFormatter, NO_QUERY_PARAMS_IN_NAME)
 
         val testCases = namingStrategy.getTestCases()
         assertEquals(3, testCases.size)
@@ -84,7 +90,7 @@ class TestCaseDisambiguationTest {
 
         val solution = Solution(mutableListOf(configurationFeatureIndividual, productFeatureIndividual), "suitePrefix", "suiteSuffix", Termination.NONE, emptyList(), emptyList())
 
-        val namingStrategy = RestActionTestCaseNamingStrategy(solution, javaFormatter)
+        val namingStrategy = RestActionTestCaseNamingStrategy(solution, javaFormatter, NO_QUERY_PARAMS_IN_NAME)
 
         val testCases = namingStrategy.getTestCases()
         assertEquals(2, testCases.size)
@@ -95,11 +101,11 @@ class TestCaseDisambiguationTest {
     @Test
     fun pathWithQueryParamDisambiguation() {
         val syntaxLanguagesIndividual = getEvaluatedIndividualWith(getRestCallAction("/syntax/languages"))
-        val syntaxLanguagesIndividualWithQP = getEvaluatedIndividualWith(getRestCallAction("/syntax/languages", parameters = singletonList(getQueryParam("myQueryParam"))))
+        val syntaxLanguagesIndividualWithQP = getEvaluatedIndividualWith(getRestCallAction("/syntax/languages", parameters = singletonList(getStringQueryParam("myQueryParam"))))
 
         val solution = Solution(mutableListOf(syntaxLanguagesIndividual, syntaxLanguagesIndividualWithQP), "suitePrefix", "suiteSuffix", Termination.NONE, emptyList(), emptyList())
 
-        val namingStrategy = RestActionTestCaseNamingStrategy(solution, javaFormatter)
+        val namingStrategy = RestActionTestCaseNamingStrategy(solution, javaFormatter, NO_QUERY_PARAMS_IN_NAME)
 
         val testCases = namingStrategy.getTestCases()
         assertEquals(2, testCases.size)
@@ -110,11 +116,11 @@ class TestCaseDisambiguationTest {
     @Test
     fun pathWithMoreThanOneQueryParamDisambiguation() {
         val syntaxLanguagesIndividual = getEvaluatedIndividualWith(getRestCallAction("/syntax/languages"))
-        val syntaxLanguagesIndividualWithQP = getEvaluatedIndividualWith(getRestCallAction("/syntax/languages", parameters = mutableListOf(getQueryParam("myQueryParam"), getQueryParam("myOtherQueryParam"))))
+        val syntaxLanguagesIndividualWithQP = getEvaluatedIndividualWith(getRestCallAction("/syntax/languages", parameters = mutableListOf(getStringQueryParam("myQueryParam"), getStringQueryParam("myOtherQueryParam"))))
 
         val solution = Solution(mutableListOf(syntaxLanguagesIndividual, syntaxLanguagesIndividualWithQP), "suitePrefix", "suiteSuffix", Termination.NONE, emptyList(), emptyList())
 
-        val namingStrategy = RestActionTestCaseNamingStrategy(solution, javaFormatter)
+        val namingStrategy = RestActionTestCaseNamingStrategy(solution, javaFormatter, NO_QUERY_PARAMS_IN_NAME)
 
         val testCases = namingStrategy.getTestCases()
         assertEquals(2, testCases.size)
@@ -126,11 +132,11 @@ class TestCaseDisambiguationTest {
     fun rootPathAndQueryParamDisambiguationReturnsThreeDifferentNames() {
         val languagesIndividual = getEvaluatedIndividualWith(getRestCallAction("/languages"))
         val syntaxLanguagesIndividual = getEvaluatedIndividualWith(getRestCallAction("/syntax/languages"))
-        val syntaxLanguagesIndividualWithQP = getEvaluatedIndividualWith(getRestCallAction("/syntax/languages", parameters = singletonList(getQueryParam("myQueryParam"))))
+        val syntaxLanguagesIndividualWithQP = getEvaluatedIndividualWith(getRestCallAction("/syntax/languages", parameters = singletonList(getStringQueryParam("myQueryParam"))))
 
         val solution = Solution(mutableListOf(languagesIndividual, syntaxLanguagesIndividual, syntaxLanguagesIndividualWithQP), "suitePrefix", "suiteSuffix", Termination.NONE, emptyList(), emptyList())
 
-        val namingStrategy = RestActionTestCaseNamingStrategy(solution, javaFormatter)
+        val namingStrategy = RestActionTestCaseNamingStrategy(solution, javaFormatter, NO_QUERY_PARAMS_IN_NAME)
 
         val testCases = namingStrategy.getTestCases()
         assertEquals(3, testCases.size)
@@ -139,12 +145,90 @@ class TestCaseDisambiguationTest {
         assertEquals("test_2_getOnLanguagesWithQueryParamReturnsEmpty", testCases[2].name)
     }
 
+    @Test
+    fun noQueryParamsAddedWhenNoQueryParamsInIndividual() {
+        val syntaxLanguagesIndividual = getEvaluatedIndividualWith(getRestCallAction("/syntax/languages"))
+        val syntaxLanguagesIndividual2 = getEvaluatedIndividualWith(getRestCallAction("/syntax/languages"))
+
+        val solution = Solution(mutableListOf(syntaxLanguagesIndividual, syntaxLanguagesIndividual2), "suitePrefix", "suiteSuffix", Termination.NONE, emptyList(), emptyList())
+
+        val namingStrategy = RestActionTestCaseNamingStrategy(solution, javaFormatter, QUERY_PARAMS_IN_NAME)
+
+        val testCases = namingStrategy.getTestCases()
+        assertEquals(2, testCases.size)
+        assertEquals("test_0_getOnLanguagesReturnsEmpty", testCases[0].name)
+        assertEquals("test_1_getOnLanguagesReturnsEmpty", testCases[1].name)
+    }
+
+    @Test
+    fun oneTrueBooleanQueryParamIsAdded() {
+        val syntaxLanguagesIndividual = getEvaluatedIndividualWith(getRestCallAction("/syntax/languages"))
+        val syntaxLanguagesIndividual2 = getEvaluatedIndividualWith(getRestCallAction("/syntax/languages", parameters = singletonList(getBooleanQueryParam("myQueryParam"))))
+        ensureBooleanGeneValue(syntaxLanguagesIndividual2, "myQueryParam", "true")
+
+        val solution = Solution(mutableListOf(syntaxLanguagesIndividual, syntaxLanguagesIndividual2), "suitePrefix", "suiteSuffix", Termination.NONE, emptyList(), emptyList())
+
+        val namingStrategy = RestActionTestCaseNamingStrategy(solution, javaFormatter, QUERY_PARAMS_IN_NAME)
+
+        val testCases = namingStrategy.getTestCases()
+        assertEquals(2, testCases.size)
+        assertEquals("test_0_getOnSyntaxLanguagesReturnsEmpty", testCases[0].name)
+        assertEquals("test_1_getOnLanguagesWithQueryParamMyQueryParamReturnsEmpty", testCases[1].name)
+    }
+
+    @Test
+    fun oneFalseBooleanQueryParamIsNotAdded() {
+        val syntaxLanguagesIndividual = getEvaluatedIndividualWith(getRestCallAction("/syntax/languages"))
+        val syntaxLanguagesIndividual2 = getEvaluatedIndividualWith(getRestCallAction("/syntax/languages", parameters = singletonList(getBooleanQueryParam("myQueryParam"))))
+        ensureBooleanGeneValue(syntaxLanguagesIndividual2, "myQueryParam", "false")
+
+        val solution = Solution(mutableListOf(syntaxLanguagesIndividual, syntaxLanguagesIndividual2), "suitePrefix", "suiteSuffix", Termination.NONE, emptyList(), emptyList())
+
+        val namingStrategy = RestActionTestCaseNamingStrategy(solution, javaFormatter, QUERY_PARAMS_IN_NAME)
+
+        val testCases = namingStrategy.getTestCases()
+        assertEquals(2, testCases.size)
+        assertEquals("test_0_getOnSyntaxLanguagesReturnsEmpty", testCases[0].name)
+        assertEquals("test_1_getOnLanguagesWithQueryParamReturnsEmpty", testCases[1].name)
+    }
+
+    @Test
+    fun onlyTrueBooleanQueryParamsAreAdded() {
+        val syntaxLanguagesIndividual = getEvaluatedIndividualWith(getRestCallAction("/syntax/languages"))
+        val syntaxLanguagesIndividual2 = getEvaluatedIndividualWith(getRestCallAction("/syntax/languages", parameters = mutableListOf(getBooleanQueryParam("firstParam"), getBooleanQueryParam("secondParam"), getStringQueryParam("thirdParam"), getBooleanQueryParam("fourthParam"))))
+        ensureBooleanGeneValue(syntaxLanguagesIndividual2, "firstParam", "true")
+        ensureBooleanGeneValue(syntaxLanguagesIndividual2, "secondParam", "false")
+        ensureBooleanGeneValue(syntaxLanguagesIndividual2, "fourthParam", "true")
+
+        val solution = Solution(mutableListOf(syntaxLanguagesIndividual, syntaxLanguagesIndividual2), "suitePrefix", "suiteSuffix", Termination.NONE, emptyList(), emptyList())
+
+        val namingStrategy = RestActionTestCaseNamingStrategy(solution, javaFormatter, QUERY_PARAMS_IN_NAME)
+
+        val testCases = namingStrategy.getTestCases()
+        assertEquals(2, testCases.size)
+        assertEquals("test_0_getOnSyntaxLanguagesReturnsEmpty", testCases[0].name)
+        assertEquals("test_1_getOnLanguagesWithQueryParamsFirstParamAndFourthParamReturnsEmpty", testCases[1].name)
+    }
+
     private fun getPathParam(paramName: String): Param {
         return PathParam(paramName, CustomMutationRateGene(paramName, StringGene(paramName), 1.0))
     }
 
-    private fun getQueryParam(paramName: String): Param {
-        return QueryParam(paramName, CustomMutationRateGene(paramName, StringGene(paramName), 1.0))
+    private fun getStringQueryParam(paramName: String): Param {
+        return QueryParam(paramName, StringGene(paramName))
+    }
+
+    private fun getBooleanQueryParam(paramName: String): Param {
+        return QueryParam(paramName, BooleanGene(paramName))
+    }
+
+    /*
+        Since the randomization used to construct the evaluated individuals might set a random boolean value,
+        we do this to ensure the one we want for unit testing
+     */
+    private fun ensureBooleanGeneValue(evaluatedIndividual: EvaluatedIndividual<RestIndividual>, paramName: String, paramValue: String) {
+        val restCallAction = evaluatedIndividual.evaluatedMainActions().last().action as RestCallAction
+        (restCallAction.parameters.filter { it.name == paramName }).forEach { (it as QueryParam).getGeneForQuery().setFromStringValue(paramValue) }
     }
 
 }

--- a/docs/options.md
+++ b/docs/options.md
@@ -249,6 +249,7 @@ There are 3 types of options:
 |`maxTestSizeStrategy`| __Enum__. Specify a strategy to handle a max size of a test. *Valid values*: `SPECIFIED, DPC_INCREASING, DPC_DECREASING`. *Default value*: `SPECIFIED`.|
 |`maxTestsPerTestSuite`| __Int__. Specify the maximum number of tests to be generated in one test suite. Note that a negative number presents no limit per test suite. *Default value*: `-1`.|
 |`mutationTargetsSelectionStrategy`| __Enum__. Specify a strategy to select targets for evaluating mutation. *Valid values*: `FIRST_NOT_COVERED_TARGET, EXPANDED_UPDATED_NOT_COVERED_TARGET, UPDATED_NOT_COVERED_TARGET`. *Default value*: `FIRST_NOT_COVERED_TARGET`.|
+|`nameWithQueryParameters`| __Boolean__. Specify if true boolean query parameters are included in the test case name. Used for test case naming disambiguation. Only valid for Action based naming strategy. *Default value*: `false`.|
 |`prematureStopStrategy`| __Enum__. Specify how 'improvement' is defined: either any kind of improvement even if partial (ANY), or at least one new target is fully covered (NEW). *Valid values*: `ANY, NEW`. *Default value*: `NEW`.|
 |`probOfHandlingLength`| __Double__. Specify a probability of applying length handling. *Constraints*: `probability 0.0-1.0`. *Default value*: `0.0`.|
 |`probOfHarvestingResponsesFromActualExternalServices`| __Double__. a probability of harvesting actual responses from external services as seeds. *Constraints*: `probability 0.0-1.0`. *Default value*: `0.0`.|


### PR DESCRIPTION
# What + Why
Adding an experimental parameter for using the names of boolean query parameters which have a `true` value in test case disambiguation.
When there's more than one eligible query param, they are joined by the `and` keyword for readability purposes