### PR TITLE
first try to fix exception related to TimeOffset impact

### DIFF
--- a/core/src/main/kotlin/org/evomaster/core/search/gene/datetime/TimeGene.kt
+++ b/core/src/main/kotlin/org/evomaster/core/search/gene/datetime/TimeGene.kt
@@ -106,8 +106,10 @@ class TimeGene(
             val maps = mapOf<Gene, GeneImpact>(
                 hour to additionalGeneMutationInfo.impact.hourGeneImpact,
                 minute to additionalGeneMutationInfo.impact.minuteGeneImpact,
-                second to additionalGeneMutationInfo.impact.secondGeneImpact
-                // TODO millisecond and offset
+                second to additionalGeneMutationInfo.impact.secondGeneImpact,
+                //TODO should be handle in a correct way
+                millisecond to additionalGeneMutationInfo.impact.millisecondGeneImpact,
+                offset to additionalGeneMutationInfo.impact.offsetGeneImpact
             )
             return mwc.selectSubGene(
                 internalGenes,

--- a/core/src/main/kotlin/org/evomaster/core/search/gene/datetime/TimeOffsetGene.kt
+++ b/core/src/main/kotlin/org/evomaster/core/search/gene/datetime/TimeOffsetGene.kt
@@ -6,7 +6,11 @@ import org.evomaster.core.search.gene.collection.EnumGene
 import org.evomaster.core.search.gene.optional.ChoiceGene
 import org.evomaster.core.search.gene.root.CompositeFixedGene
 import org.evomaster.core.search.gene.utils.GeneUtils
+import org.evomaster.core.search.impact.impactinfocollection.CompositeFixedGeneImpact
+import org.evomaster.core.search.impact.impactinfocollection.GeneImpact
+import org.evomaster.core.search.impact.impactinfocollection.value.date.TimeOffsetGeneImpact
 import org.evomaster.core.search.service.Randomness
+import org.evomaster.core.search.service.mutator.MutationWeightControl
 import org.evomaster.core.search.service.mutator.genemutation.AdditionalGeneMutationInfo
 import org.evomaster.core.search.service.mutator.genemutation.SubsetGeneMutationSelectionStrategy
 
@@ -86,4 +90,26 @@ class TimeOffsetGene(
         return false
     }
 
+    override fun adaptiveSelectSubsetToMutate(
+        randomness: Randomness,
+        internalGenes: List<Gene>,
+        mwc: MutationWeightControl,
+        additionalGeneMutationInfo: AdditionalGeneMutationInfo
+    ): List<Pair<Gene, AdditionalGeneMutationInfo?>> {
+        if (additionalGeneMutationInfo.impact != null && additionalGeneMutationInfo.impact is TimeOffsetGeneImpact) {
+            val maps = mapOf<Gene, GeneImpact>(
+                type to additionalGeneMutationInfo.impact.typeImpact
+            )
+            return mwc.selectSubGene(
+                internalGenes,
+                adaptiveWeight = true,
+                targets = additionalGeneMutationInfo.targets,
+                impacts = internalGenes.map { i -> maps.getValue(i) },
+                individual = null,
+                evi = additionalGeneMutationInfo.evi
+            )
+                .map { it to additionalGeneMutationInfo.copyFoInnerGene(maps.getValue(it), it) }
+        }
+        throw IllegalArgumentException("impact is null or not TimeOffsetGeneImpact")
+    }
 }

--- a/core/src/main/kotlin/org/evomaster/core/search/impact/impactinfocollection/ImpactUtils.kt
+++ b/core/src/main/kotlin/org/evomaster/core/search/impact/impactinfocollection/ImpactUtils.kt
@@ -22,6 +22,7 @@ import org.evomaster.core.search.gene.collection.*
 import org.evomaster.core.search.gene.datetime.DateGene
 import org.evomaster.core.search.gene.datetime.DateTimeGene
 import org.evomaster.core.search.gene.datetime.TimeGene
+import org.evomaster.core.search.gene.datetime.TimeOffsetGene
 import org.evomaster.core.search.gene.numeric.*
 import org.evomaster.core.search.gene.optional.CustomMutationRateGene
 import org.evomaster.core.search.gene.optional.OptionalGene
@@ -32,6 +33,7 @@ import org.evomaster.core.search.gene.string.NumericStringGene
 import org.evomaster.core.search.gene.string.StringGene
 import org.evomaster.core.search.impact.impactinfocollection.regex.*
 import org.evomaster.core.search.impact.impactinfocollection.value.collection.SqlMultidimensionalArrayGeneImpact
+import org.evomaster.core.search.impact.impactinfocollection.value.date.TimeOffsetGeneImpact
 import org.evomaster.core.search.service.mutator.MutatedGeneSpecification
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
@@ -70,6 +72,7 @@ class ImpactUtils {
                 is DateGene -> DateGeneImpact(id, gene)
                 is DateTimeGene -> DateTimeGeneImpact(id, gene)
                 is TimeGene -> TimeGeneImpact(id, gene)
+                is TimeOffsetGene -> TimeOffsetGeneImpact(id, gene)
                 is SeededGene<*> -> SeededGeneImpact(id, gene)
                 // math
                 is BigDecimalGene -> BigDecimalGeneImpact(id)

--- a/core/src/main/kotlin/org/evomaster/core/search/impact/impactinfocollection/value/date/TimeGeneImpact.kt
+++ b/core/src/main/kotlin/org/evomaster/core/search/impact/impactinfocollection/value/date/TimeGeneImpact.kt
@@ -3,22 +3,28 @@ package org.evomaster.core.search.impact.impactinfocollection.value.date
 import org.evomaster.core.search.gene.Gene
 import org.evomaster.core.search.gene.datetime.TimeGene
 import org.evomaster.core.search.impact.impactinfocollection.*
+import org.evomaster.core.search.impact.impactinfocollection.value.OptionalGeneImpact
 import org.evomaster.core.search.impact.impactinfocollection.value.numeric.IntegerGeneImpact
 
 /**
  * created by manzh on 2019-09-16
  */
-class TimeGeneImpact(sharedImpactInfo: SharedImpactInfo, specificImpactInfo: SpecificImpactInfo,
-                     val hourGeneImpact: IntegerGeneImpact,
-                     val minuteGeneImpact: IntegerGeneImpact,
-                     val secondGeneImpact : IntegerGeneImpact
+class TimeGeneImpact(
+    sharedImpactInfo: SharedImpactInfo, specificImpactInfo: SpecificImpactInfo,
+    val hourGeneImpact: IntegerGeneImpact,
+    val minuteGeneImpact: IntegerGeneImpact,
+    val secondGeneImpact: IntegerGeneImpact,
+    val millisecondGeneImpact: OptionalGeneImpact,
+    val offsetGeneImpact: TimeOffsetGeneImpact
 ) : GeneImpact(sharedImpactInfo, specificImpactInfo){
 
     constructor(id: String, gene : TimeGene)
             : this(SharedImpactInfo(id), SpecificImpactInfo(),
             hourGeneImpact = ImpactUtils.createGeneImpact(gene.hour, gene.hour.name) as? IntegerGeneImpact ?:throw IllegalStateException("IntegerGeneImpact should be created"),
             minuteGeneImpact = ImpactUtils.createGeneImpact(gene.minute, gene.minute.name)as? IntegerGeneImpact ?:throw IllegalStateException("IntegerGeneImpact should be created"),
-            secondGeneImpact = ImpactUtils.createGeneImpact(gene.second, gene.second.name) as? IntegerGeneImpact ?:throw IllegalStateException("IntegerGeneImpact should be created")
+            secondGeneImpact = ImpactUtils.createGeneImpact(gene.second, gene.second.name) as? IntegerGeneImpact ?:throw IllegalStateException("IntegerGeneImpact should be created"),
+            millisecondGeneImpact = ImpactUtils.createGeneImpact(gene.millisecond, gene.millisecond.name) as? OptionalGeneImpact ?:throw IllegalStateException("IntegerGeneImpact should be created"),
+            offsetGeneImpact = ImpactUtils.createGeneImpact(gene.offset, gene.offset.name) as? TimeOffsetGeneImpact ?:throw IllegalStateException("TimeOffsetGeneImpact should be created")
     )
 
     override fun copy(): TimeGeneImpact {
@@ -27,12 +33,14 @@ class TimeGeneImpact(sharedImpactInfo: SharedImpactInfo, specificImpactInfo: Spe
                 specific.copy(),
                 hourGeneImpact = hourGeneImpact.copy(),
                 minuteGeneImpact = minuteGeneImpact.copy(),
-                secondGeneImpact = secondGeneImpact.copy())
+                secondGeneImpact = secondGeneImpact.copy(),
+                millisecondGeneImpact = millisecondGeneImpact.copy(),
+                offsetGeneImpact = offsetGeneImpact.copy())
     }
 
     override fun clone(): TimeGeneImpact {
         return TimeGeneImpact(
-                shared.clone(),specific.clone(), hourGeneImpact = hourGeneImpact.clone(), minuteGeneImpact = minuteGeneImpact.clone(), secondGeneImpact = secondGeneImpact.clone()
+                shared.clone(),specific.clone(), hourGeneImpact = hourGeneImpact.clone(), minuteGeneImpact = minuteGeneImpact.clone(), secondGeneImpact = secondGeneImpact.clone(), millisecondGeneImpact = millisecondGeneImpact.clone(), offsetGeneImpact = offsetGeneImpact.clone()
         )
     }
 
@@ -58,6 +66,7 @@ class TimeGeneImpact(sharedImpactInfo: SharedImpactInfo, specificImpactInfo: Spe
         if (gc.previous == null || !gc.current.second.containsSameValueAs((gc.previous as TimeGene).second))
             innerImpacts.add(secondGeneImpact)
 
+
         if (innerImpacts.isEmpty()) return
         countImpactAndPerformance(noImpactTargets = noImpactTargets, impactTargets = impactTargets, improvedTargets = improvedTargets, onlyManipulation = onlyManipulation, num = gc.numOfMutatedGene)
         innerImpacts.forEach {
@@ -70,11 +79,13 @@ class TimeGeneImpact(sharedImpactInfo: SharedImpactInfo, specificImpactInfo: Spe
         return mutableMapOf(
                 "${getId()}-${hourGeneImpact.getId()}" to hourGeneImpact,
                 "${getId()}-${minuteGeneImpact.getId()}" to minuteGeneImpact,
-                "${getId()}-${secondGeneImpact.getId()}" to secondGeneImpact
+                "${getId()}-${secondGeneImpact.getId()}" to secondGeneImpact,
+                "${getId()}-${millisecondGeneImpact.getId()}" to millisecondGeneImpact,
+                "${getId()}-${offsetGeneImpact.getId()}" to offsetGeneImpact
         )
     }
 
     override fun innerImpacts(): List<Impact> {
-        return listOf(hourGeneImpact, minuteGeneImpact, secondGeneImpact)
+        return listOf(hourGeneImpact, minuteGeneImpact, secondGeneImpact, millisecondGeneImpact, offsetGeneImpact)
     }
 }

--- a/core/src/main/kotlin/org/evomaster/core/search/impact/impactinfocollection/value/date/TimeGeneImpact.kt
+++ b/core/src/main/kotlin/org/evomaster/core/search/impact/impactinfocollection/value/date/TimeGeneImpact.kt
@@ -57,7 +57,7 @@ class TimeGeneImpact(
         if (gc.previous != null && gc.previous !is TimeGene)
             throw IllegalStateException("gc.previous (${gc.previous::class.java.simpleName}) should be TimeGene")
 
-        val innerImpacts = mutableListOf<IntegerGeneImpact>()
+        val innerImpacts = mutableListOf<GeneImpact>()
 
         if (gc.previous == null || !gc.current.hour.containsSameValueAs((gc.previous as TimeGene).hour))
             innerImpacts.add(hourGeneImpact)
@@ -66,6 +66,11 @@ class TimeGeneImpact(
         if (gc.previous == null || !gc.current.second.containsSameValueAs((gc.previous as TimeGene).second))
             innerImpacts.add(secondGeneImpact)
 
+        if (gc.previous == null || !gc.current.millisecond.containsSameValueAs((gc.previous as TimeGene).millisecond))
+            innerImpacts.add(millisecondGeneImpact)
+
+        if (gc.previous == null || !gc.current.offset.containsSameValueAs((gc.previous as TimeGene).offset))
+            innerImpacts.add(offsetGeneImpact)
 
         if (innerImpacts.isEmpty()) return
         countImpactAndPerformance(noImpactTargets = noImpactTargets, impactTargets = impactTargets, improvedTargets = improvedTargets, onlyManipulation = onlyManipulation, num = gc.numOfMutatedGene)

--- a/core/src/main/kotlin/org/evomaster/core/search/impact/impactinfocollection/value/date/TimeOffsetGeneImpact.kt
+++ b/core/src/main/kotlin/org/evomaster/core/search/impact/impactinfocollection/value/date/TimeOffsetGeneImpact.kt
@@ -1,0 +1,37 @@
+package org.evomaster.core.search.impact.impactinfocollection.value.date
+
+import org.evomaster.core.search.gene.Gene
+import org.evomaster.core.search.gene.datetime.TimeGene
+import org.evomaster.core.search.gene.datetime.TimeOffsetGene
+import org.evomaster.core.search.gene.root.CompositeFixedGene
+import org.evomaster.core.search.impact.impactinfocollection.*
+import org.evomaster.core.search.impact.impactinfocollection.value.numeric.IntegerGeneImpact
+
+//TODO should be handle in a correct way
+class TimeOffsetGeneImpact(sharedImpactInfo: SharedImpactInfo, specificImpactInfo: SpecificImpactInfo,
+                           val typeImpact: CompositeFixedGeneImpact
+) : GeneImpact(sharedImpactInfo, specificImpactInfo) {
+
+    constructor(id: String, gene : TimeOffsetGene)
+            : this(SharedImpactInfo(id), SpecificImpactInfo(),
+        typeImpact = ImpactUtils.createGeneImpact(gene.type, gene.type.name) as? CompositeFixedGeneImpact ?:throw IllegalStateException("CompositeFixedGeneImpact should be created"),
+    )
+
+    override fun copy(): TimeOffsetGeneImpact {
+        return TimeOffsetGeneImpact(
+                shared.copy(),
+                specific.copy(),
+                typeImpact = typeImpact.copy()
+        )
+    }
+
+    override fun clone(): TimeOffsetGeneImpact {
+        return TimeOffsetGeneImpact(
+                shared.clone(),specific.clone(),
+            typeImpact = typeImpact.clone()
+        )
+    }
+
+    override fun validate(gene: Gene): Boolean = gene is TimeOffsetGene
+
+}

--- a/core/src/test/kotlin/org/evomaster/core/search/impact/impactinfocollection/date/TimeGeneImpactTest.kt
+++ b/core/src/test/kotlin/org/evomaster/core/search/impact/impactinfocollection/date/TimeGeneImpactTest.kt
@@ -3,6 +3,7 @@ package org.evomaster.core.search.impact.impactinfocollection.date
 import org.evomaster.core.search.gene.Gene
 import org.evomaster.core.search.gene.numeric.IntegerGene
 import org.evomaster.core.search.gene.datetime.TimeGene
+import org.evomaster.core.search.gene.optional.OptionalGene
 import org.evomaster.core.search.impact.impactinfocollection.GeneImpact
 import org.evomaster.core.search.impact.impactinfocollection.GeneImpactTest
 import org.evomaster.core.search.impact.impactinfocollection.ImpactOptions
@@ -16,7 +17,11 @@ import org.junit.jupiter.api.Test
 class TimeGeneImpactTest : GeneImpactTest() {
 
     override fun getGene(): Gene {
-        return TimeGene("d", hour = IntegerGene("h", 16), minute = IntegerGene("m", 36), second = IntegerGene("s", 9))
+        return TimeGene("d",
+            hour = IntegerGene("h", 16),
+            minute = IntegerGene("m", 36),
+            second = IntegerGene("s", 9),
+            millisecond = OptionalGene("millisecond", IntegerGene("millisecond", 42)))
     }
 
     override fun checkImpactType(impact: GeneImpact) {
@@ -30,6 +35,7 @@ class TimeGeneImpactTest : GeneImpactTest() {
                 mutationTag == 0 -> hour.value = (hour.value + 1)%24
                 mutationTag == 1 -> minute.value = (minute.value + 1)%60
                 mutationTag == 2 -> second.value = (second.value + 1)%60
+                mutationTag == 3 -> ((millisecond as OptionalGene).gene as IntegerGene).value = (((millisecond as OptionalGene).gene as IntegerGene).value + 1)%1000
                 else -> throw IllegalArgumentException("bug")
             }
         }
@@ -48,6 +54,8 @@ class TimeGeneImpactTest : GeneImpactTest() {
         assertImpact(impact.hourGeneImpact, updatedImpact.hourGeneImpact, ImpactOptions.IMPACT_IMPROVEMENT)
         assertImpact(impact.minuteGeneImpact, updatedImpact.minuteGeneImpact, ImpactOptions.NONE)
         assertImpact(impact.secondGeneImpact, updatedImpact.secondGeneImpact, ImpactOptions.NONE)
+        assertImpact(impact.millisecondGeneImpact, updatedImpact.millisecondGeneImpact, ImpactOptions.NONE)
+        assertImpact(impact.offsetGeneImpact, updatedImpact.offsetGeneImpact, ImpactOptions.NONE)
     }
 
     @Test
@@ -61,6 +69,8 @@ class TimeGeneImpactTest : GeneImpactTest() {
         assertImpact(impact.hourGeneImpact, updatedImpact.hourGeneImpact, ImpactOptions.NONE)
         assertImpact(impact.minuteGeneImpact, updatedImpact.minuteGeneImpact, ImpactOptions.NO_IMPACT)
         assertImpact(impact.secondGeneImpact, updatedImpact.secondGeneImpact, ImpactOptions.NONE)
+        assertImpact(impact.millisecondGeneImpact, updatedImpact.millisecondGeneImpact, ImpactOptions.NONE)
+        assertImpact(impact.offsetGeneImpact, updatedImpact.offsetGeneImpact, ImpactOptions.NONE)
     }
 
     @Test
@@ -74,5 +84,22 @@ class TimeGeneImpactTest : GeneImpactTest() {
         assertImpact(impact.hourGeneImpact, updatedImpact.hourGeneImpact, ImpactOptions.NONE)
         assertImpact(impact.minuteGeneImpact, updatedImpact.minuteGeneImpact, ImpactOptions.NONE)
         assertImpact(impact.secondGeneImpact, updatedImpact.secondGeneImpact, ImpactOptions.ONLY_IMPACT)
+        assertImpact(impact.millisecondGeneImpact, updatedImpact.millisecondGeneImpact, ImpactOptions.NONE)
+        assertImpact(impact.offsetGeneImpact, updatedImpact.offsetGeneImpact, ImpactOptions.NONE)
+    }
+
+    @Test
+    fun testMillisecond(){
+        val gene = getGene()
+        val impact = initImpact(gene)
+        val updatedImpact = template( gene, impact, listOf(ImpactOptions.IMPACT_IMPROVEMENT), 3).second
+
+        impact as TimeGeneImpact
+        updatedImpact as TimeGeneImpact
+        assertImpact(impact.hourGeneImpact, updatedImpact.hourGeneImpact, ImpactOptions.NONE)
+        assertImpact(impact.minuteGeneImpact, updatedImpact.minuteGeneImpact, ImpactOptions.NONE)
+        assertImpact(impact.secondGeneImpact, updatedImpact.secondGeneImpact, ImpactOptions.NONE)
+        assertImpact(impact.millisecondGeneImpact, updatedImpact.millisecondGeneImpact, ImpactOptions.IMPACT_IMPROVEMENT)
+        assertImpact(impact.offsetGeneImpact, updatedImpact.offsetGeneImpact, ImpactOptions.NONE)
     }
 }


### PR DESCRIPTION
In src/main/kotlin/org/evomaster/core/search/gene/datetime/TimeGene.kt, millisecond and ofsett are missing. That causes "java.util.NoSuchElementException: Key org.evomaster.core.search.gene.optional.OptionalGene@820b78a is missing in the map." exception while running on the SUTs.

In this PR, I fixed it, but we need to check if it is the correct way.

Stacktrace:
> * Starting to generate test cases
20:33:19.044 [main] WARN  o.e.c.s.i.i.ImpactUtils - the impact of LimitObjectGene was collected in a general manner, i.e., GeneImpact
20:33:19.205 [main] WARN  o.e.c.s.i.i.ImpactUtils - the impact of CycleObjectGene was collected in a general manner, i.e., GeneImpact EvoMaster process terminated abruptly. This is likely a bug in EvoMaster. Please copy&paste the following stacktrace, and create a new issue on [34mhttps://github.com/EMResearch/EvoMaster/issues[0m[0m
java.util.NoSuchElementException: Key org.evomaster.core.search.gene.optional.OptionalGene@7417ef4f is missing in the map.
	at kotlin.collections.MapsKt__MapWithDefaultKt.getOrImplicitDefaultNullable(MapWithDefault.kt:24)
	at kotlin.collections.MapsKt__MapsKt.getValue(Maps.kt:349)
	at org.evomaster.core.search.gene.datetime.TimeGene.adaptiveSelectSubsetToMutate(TimeGene.kt:116)
	at org.evomaster.core.search.gene.Gene.selectSubsetToMutate(Gene.kt:665)
	at org.evomaster.core.search.gene.Gene.standardMutation(Gene.kt:574)
	at org.evomaster.core.search.gene.Gene.standardMutation(Gene.kt:581)
	at org.evomaster.core.search.service.mutator.StandardMutator.innerMutate(StandardMutator.kt:278)
	at org.evomaster.core.search.service.mutator.StandardMutator.mutate(StandardMutator.kt:301)
	at org.evomaster.core.search.service.mutator.Mutator.mutateAndSave(Mutator.kt:163)
	at org.evomaster.core.search.algorithms.MioAlgorithm.searchOnce(MioAlgorithm.kt:48)
	at org.evomaster.core.search.service.SearchAlgorithm.search(SearchAlgorithm.kt:77)
	at org.evomaster.core.Main$Companion.run(Main.kt:579)
	at org.evomaster.core.Main$Companion.initAndRun(Main.kt:175)
	at org.evomaster.core.Main$Companion.main(Main.kt:85)
	at org.evomaster.core.Main.main(Main.kt)

![image](https://github.com/user-attachments/assets/341f9713-26d4-46a3-a702-cb4e8a5520d7)
