### PR TITLE
Phg/test case sorting

### DIFF
--- a/core/src/main/kotlin/org/evomaster/core/EMConfig.kt
+++ b/core/src/main/kotlin/org/evomaster/core/EMConfig.kt
@@ -12,6 +12,7 @@ import org.evomaster.core.config.ConfigsFromFile
 import org.evomaster.core.logging.LoggingUtil
 import org.evomaster.core.output.OutputFormat
 import org.evomaster.core.output.naming.NamingStrategy
+import org.evomaster.core.output.sorting.SortingStrategy
 import org.evomaster.core.search.impact.impactinfocollection.GeneMutationSelectionMethod
 import org.evomaster.core.search.service.IdMapper
 import org.slf4j.LoggerFactory
@@ -82,6 +83,8 @@ class EMConfig {
         private val defaultOutputFormatForBlackBox = OutputFormat.PYTHON_UNITTEST
 
         private val defaultTestCaseNamingStrategy = NamingStrategy.NUMBERED
+
+        private val defaultTestCaseSortingStrategy = SortingStrategy.COVERED_TARGETS
 
         fun validateOptions(args: Array<String>): OptionParser {
 
@@ -2432,6 +2435,8 @@ class EMConfig {
             " Used for test case naming disambiguation. Only valid for Action based naming strategy.")
     var nameWithQueryParameters = false
 
+    @Cfg("Specify the test case sorting strategy")
+    var testCaseSortingStrategy = defaultTestCaseSortingStrategy
 
     @Experimental
     @Probability(true)

--- a/core/src/main/kotlin/org/evomaster/core/output/TestSuiteOrganizer.kt
+++ b/core/src/main/kotlin/org/evomaster/core/output/TestSuiteOrganizer.kt
@@ -196,7 +196,7 @@ class SortingHelper {
      */
 
     var comparatorList = listOf(statusCode, coveredTargets)
-    var restComparator: Comparator<EvaluatedIndividual<*>> = compareBy<EvaluatedIndividual<*>> { ind ->
+    val restComparator: Comparator<EvaluatedIndividual<*>> = compareBy<EvaluatedIndividual<*>> { ind ->
         if (ind.individual is RestIndividual) {
             (ind.evaluatedMainActions().last().action as RestCallAction).path.levels()
         } else 0
@@ -266,7 +266,6 @@ class SortingHelper {
          */
 
         return namingStrategy.getSortedTestCases(restComparator)
-
     }
 
     fun sort(solution: Solution<*>, namingStrategy: TestCaseNamingStrategy): List<TestCase> {

--- a/core/src/main/kotlin/org/evomaster/core/output/TestSuiteOrganizer.kt
+++ b/core/src/main/kotlin/org/evomaster/core/output/TestSuiteOrganizer.kt
@@ -1,14 +1,22 @@
 package org.evomaster.core.output
 
 import org.evomaster.core.Lazy
-import org.evomaster.core.output.service.PartialOracles
 import org.evomaster.core.output.naming.TestCaseNamingStrategy
+import org.evomaster.core.output.service.PartialOracles
+import org.evomaster.core.output.sorting.SortingStrategy
+import org.evomaster.core.problem.graphql.GraphQLAction
+import org.evomaster.core.problem.graphql.GraphQLIndividual
 import org.evomaster.core.problem.httpws.HttpWsCallResult
 import org.evomaster.core.problem.rest.HttpVerb
 import org.evomaster.core.problem.rest.RestCallAction
 import org.evomaster.core.problem.rest.RestIndividual
+import org.evomaster.core.problem.rpc.RPCCallAction
+import org.evomaster.core.problem.rpc.RPCIndividual
+import org.evomaster.core.problem.webfrontend.WebIndividual
 import org.evomaster.core.search.EvaluatedIndividual
 import org.evomaster.core.search.Solution
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
 import kotlin.reflect.KFunction1
 
 /**
@@ -28,10 +36,10 @@ class TestSuiteOrganizer {
 
     private val defaultSorting = listOf(0, 1)
 
-    fun sortTests(solution: Solution<*>, namingStrategy: TestCaseNamingStrategy): List<TestCase> {
+    fun sortTests(solution: Solution<*>, namingStrategy: TestCaseNamingStrategy, testCaseSortingStrategy: SortingStrategy): List<TestCase> {
         //sortingHelper.selectCriteriaByIndex(defaultSorting)
         //TODO here in the future we will have something a bit smarter
-        return sortingHelper.sort(solution, namingStrategy)
+        return sortingHelper.sort(solution, namingStrategy, testCaseSortingStrategy)
     }
 
 //    fun setPartialOracles(partialOracles: PartialOracles){
@@ -135,6 +143,10 @@ class NamingHelper {
 
 class SortingHelper {
 
+    companion object {
+        private val log: Logger = LoggerFactory.getLogger(SortingHelper::class.java)
+    }
+
     /** [maxStatusCode] sorts Evaluated individuals based on the highest status code (e.g., 500s are first).
      *
      * **/
@@ -196,11 +208,10 @@ class SortingHelper {
      */
 
     var comparatorList = listOf(statusCode, coveredTargets)
+
     val restComparator: Comparator<EvaluatedIndividual<*>> = compareBy<EvaluatedIndividual<*>> { ind ->
-        if (ind.individual is RestIndividual) {
             (ind.evaluatedMainActions().last().action as RestCallAction).path.levels()
-        } else 0
-    }
+        }
         .thenBy { ind ->
             val min = ind.seeResults().filterIsInstance<HttpWsCallResult>().minByOrNull {
                 it.getStatusCode()?.rem(500) ?: 0
@@ -208,9 +219,27 @@ class SortingHelper {
             (min?.getStatusCode())?.rem(500) ?: 0
         }
         .thenBy { ind ->
-            if (ind.individual is RestIndividual) {
-                (ind.evaluatedMainActions().last().action as RestCallAction).verb
-            } else 0
+            (ind.evaluatedMainActions().last().action as RestCallAction).verb
+        }
+
+    val graphQLComparator: Comparator<EvaluatedIndividual<*>> = compareBy<EvaluatedIndividual<*>> { ind ->
+            (ind.evaluatedMainActions().last().action as GraphQLAction).methodName
+        }
+        .thenBy { ind ->
+            (ind.evaluatedMainActions().last().action as GraphQLAction).methodType
+        }
+        .thenBy { ind ->
+            (ind.evaluatedMainActions().last().action as GraphQLAction).parameters.size
+        }
+
+    val rpcComparator: Comparator<EvaluatedIndividual<*>> = compareBy<EvaluatedIndividual<*>> { ind ->
+            (ind.evaluatedMainActions().last().action as RPCCallAction).getSimpleClassName()
+        }
+        .thenBy { ind ->
+            (ind.evaluatedMainActions().last().action as RPCCallAction).getExecutedFunctionName()
+        }
+        .thenBy { ind ->
+            (ind.evaluatedMainActions().last().action as RPCCallAction).parameters.size
         }
 
     private val availableSortCriteria = listOf(statusCode, minActions, coveredTargets, maxStatusCode, maxActions, dbInitSize)
@@ -265,11 +294,31 @@ class SortingHelper {
          * that have the same code, the ones with the most covered targets will be at the top (among their sub-group).
          */
 
-        return namingStrategy.getSortedTestCases(restComparator)
+        return namingStrategy.getSortedTestCases(comparators)
     }
 
-    fun sort(solution: Solution<*>, namingStrategy: TestCaseNamingStrategy): List<TestCase> {
-        val newSort = sortByComparatorList(comparatorList, namingStrategy)
+    private fun sortByTargetIncremental(solution: Solution<*>, namingStrategy: TestCaseNamingStrategy): List<TestCase> {
+        val individuals = solution.individuals
+        val comparator = when {
+            individuals.any { it.individual is RestIndividual } -> restComparator
+            individuals.any { it.individual is GraphQLIndividual } -> graphQLComparator
+            individuals.any { it.individual is RPCIndividual } -> rpcComparator
+            individuals.any { it.individual is WebIndividual } -> {
+                log.warn("Web individuals do not have action based test case naming yet. Defaulting to Numbered strategy.")
+                statusCode
+            }
+            else -> throw IllegalStateException("Unrecognized test individuals with no target incremental based sorting strategy set.")
+        }
+
+        return namingStrategy.getSortedTestCases(comparator)
+    }
+
+    fun sort(solution: Solution<*>, namingStrategy: TestCaseNamingStrategy, testCaseSortingStrategy: SortingStrategy): List<TestCase> {
+        val newSort = when {
+            testCaseSortingStrategy.isCoveredTargets() -> sortByComparatorList(comparatorList, namingStrategy)
+            testCaseSortingStrategy.isTargetIncremental() -> sortByTargetIncremental(solution, namingStrategy)
+            else -> throw IllegalStateException("Unrecognized sorting strategy $testCaseSortingStrategy")
+        }
 
         Lazy.assert { solution.individuals.toSet() == newSort.map { it.test }.toSet()}
         return newSort

--- a/core/src/main/kotlin/org/evomaster/core/output/TestSuiteOrganizer.kt
+++ b/core/src/main/kotlin/org/evomaster/core/output/TestSuiteOrganizer.kt
@@ -314,9 +314,9 @@ class SortingHelper {
     }
 
     fun sort(solution: Solution<*>, namingStrategy: TestCaseNamingStrategy, testCaseSortingStrategy: SortingStrategy): List<TestCase> {
-        val newSort = when {
-            testCaseSortingStrategy.isCoveredTargets() -> sortByComparatorList(comparatorList, namingStrategy)
-            testCaseSortingStrategy.isTargetIncremental() -> sortByTargetIncremental(solution, namingStrategy)
+        val newSort = when (testCaseSortingStrategy) {
+            SortingStrategy.COVERED_TARGETS -> sortByComparatorList(comparatorList, namingStrategy)
+            SortingStrategy.TARGET_INCREMENTAL -> sortByTargetIncremental(solution, namingStrategy)
             else -> throw IllegalStateException("Unrecognized sorting strategy $testCaseSortingStrategy")
         }
 

--- a/core/src/main/kotlin/org/evomaster/core/output/naming/NumberedTestCaseNamingStrategy.kt
+++ b/core/src/main/kotlin/org/evomaster/core/output/naming/NumberedTestCaseNamingStrategy.kt
@@ -16,9 +16,9 @@ open class NumberedTestCaseNamingStrategy(
     override fun getSortedTestCases(comparator: Comparator<EvaluatedIndividual<*>>): List<TestCase> {
         val inds = solution.individuals
 
-        val sortedIndividuals = inds.sortedWith(comparator)
+        inds.sortWith(comparator)
 
-        return generateNames(sortedIndividuals)
+        return generateNames(inds)
     }
 
     // numbered strategy will not expand the name unless it is using the namingHelper

--- a/core/src/main/kotlin/org/evomaster/core/output/naming/NumberedTestCaseNamingStrategy.kt
+++ b/core/src/main/kotlin/org/evomaster/core/output/naming/NumberedTestCaseNamingStrategy.kt
@@ -13,12 +13,12 @@ open class NumberedTestCaseNamingStrategy(
         return generateNames(solution.individuals)
     }
 
-    override fun getSortedTestCases(comparators: List<Comparator<EvaluatedIndividual<*>>>): List<TestCase> {
+    override fun getSortedTestCases(comparator: Comparator<EvaluatedIndividual<*>>): List<TestCase> {
         val inds = solution.individuals
-        comparators.asReversed().forEach {
-            inds.sortWith(it)
-        }
-        return generateNames(inds)
+
+        val sortedIndividuals = inds.sortedWith(comparator)
+
+        return generateNames(sortedIndividuals)
     }
 
     // numbered strategy will not expand the name unless it is using the namingHelper

--- a/core/src/main/kotlin/org/evomaster/core/output/naming/NumberedTestCaseNamingStrategy.kt
+++ b/core/src/main/kotlin/org/evomaster/core/output/naming/NumberedTestCaseNamingStrategy.kt
@@ -4,6 +4,7 @@ import org.evomaster.core.output.TestCase
 import org.evomaster.core.search.EvaluatedIndividual
 import org.evomaster.core.search.Solution
 import org.evomaster.core.search.action.Action
+import java.util.Collections.singletonList
 
 open class NumberedTestCaseNamingStrategy(
     solution: Solution<*>
@@ -14,9 +15,15 @@ open class NumberedTestCaseNamingStrategy(
     }
 
     override fun getSortedTestCases(comparator: Comparator<EvaluatedIndividual<*>>): List<TestCase> {
+        return getSortedTestCases(singletonList(comparator))
+    }
+
+    override fun getSortedTestCases(comparators: List<Comparator<EvaluatedIndividual<*>>>): List<TestCase> {
         val inds = solution.individuals
 
-        inds.sortWith(comparator)
+        comparators.asReversed().forEach {
+            inds.sortWith(it)
+        }
 
         return generateNames(inds)
     }

--- a/core/src/main/kotlin/org/evomaster/core/output/naming/TestCaseNamingStrategy.kt
+++ b/core/src/main/kotlin/org/evomaster/core/output/naming/TestCaseNamingStrategy.kt
@@ -19,11 +19,18 @@ abstract class TestCaseNamingStrategy(
     abstract fun getTestCases(): List<TestCase>
 
     /**
-     * @param comparators used to sort the test cases
+     * @param comparator used to sort the test cases
      *
      * @return the list of sorted TestCase with the generated name given the naming strategy
      */
     abstract fun getSortedTestCases(comparator: Comparator<EvaluatedIndividual<*>>): List<TestCase>
+
+    /**
+     * @param comparators used to sort the test cases
+     *
+     * @return the list of sorted TestCase with the generated name given the naming strategy
+     */
+    abstract fun getSortedTestCases(comparators: List<Comparator<EvaluatedIndividual<*>>>): List<TestCase>
 
     /**
      * @param individual containing information for the test about to be named

--- a/core/src/main/kotlin/org/evomaster/core/output/naming/TestCaseNamingStrategy.kt
+++ b/core/src/main/kotlin/org/evomaster/core/output/naming/TestCaseNamingStrategy.kt
@@ -23,7 +23,7 @@ abstract class TestCaseNamingStrategy(
      *
      * @return the list of sorted TestCase with the generated name given the naming strategy
      */
-    abstract fun getSortedTestCases(comparators: List<Comparator<EvaluatedIndividual<*>>>): List<TestCase>
+    abstract fun getSortedTestCases(comparator: Comparator<EvaluatedIndividual<*>>): List<TestCase>
 
     /**
      * @param individual containing information for the test about to be named

--- a/core/src/main/kotlin/org/evomaster/core/output/service/TestSuiteWriter.kt
+++ b/core/src/main/kotlin/org/evomaster/core/output/service/TestSuiteWriter.kt
@@ -144,7 +144,7 @@ class TestSuiteWriter {
         //catch any sorting problems (see NPE is SortingHelper on Trello)
         val tests = try {
             // TODO skip to sort RPC for the moment
-                testSuiteOrganizer.sortTests(solution, namingStrategy)
+                testSuiteOrganizer.sortTests(solution, namingStrategy, config.testCaseSortingStrategy)
         } catch (ex: Exception) {
             log.warn(
                 "A failure has occurred with the test sorting. Reverting to default settings. \n"

--- a/core/src/main/kotlin/org/evomaster/core/output/sorting/SortingStrategy.kt
+++ b/core/src/main/kotlin/org/evomaster/core/output/sorting/SortingStrategy.kt
@@ -1,0 +1,11 @@
+package org.evomaster.core.output.sorting
+
+enum class SortingStrategy {
+
+    COVERED_TARGETS,
+    TARGET_INCREMENTAL
+    ;
+
+    fun isCoveredTargets() = this.name.equals("covered_targets", true)
+    fun isTargetIncremental() = this.name.equals("target_incremental", true)
+}

--- a/core/src/main/kotlin/org/evomaster/core/output/sorting/SortingStrategy.kt
+++ b/core/src/main/kotlin/org/evomaster/core/output/sorting/SortingStrategy.kt
@@ -1,11 +1,30 @@
 package org.evomaster.core.output.sorting
 
+import org.evomaster.core.search.EvaluatedIndividual
+
+/**
+ * Sorting strategies will determine the order of the written test cases in the resulting suite.
+ */
 enum class SortingStrategy {
 
+    /**
+     * Will sort by priority:
+     * - First: status codes. 500 responses go first, then 2xx and last 4xx
+     * - Second: [EvaluatedIndividual] objects on based on the higher number of covered targets. The  purpose is to
+     * give an example of sorting based on fitness information.
+      */
     COVERED_TARGETS,
+
+    /**
+     * Will sort depending on the [ProblemType], using the following characteristics:
+     * - REST: amount of path segments, status code (like in [COVERED_TARGETS]), and last [HttpVerb].
+     * - GraphQL: method name, method type (query/mutation), and last amount of parameters.
+     * - RPC: class name of the function being tested, function name, and last amount of parameters.
+     *
+     * The goal is to provide an incremental way of reading tests. For example in REST, a developer would usually test
+     * the first (least path segments) and then go moving up the most complex paths.
+     */
     TARGET_INCREMENTAL
     ;
 
-    fun isCoveredTargets() = this.name.equals("covered_targets", true)
-    fun isTargetIncremental() = this.name.equals("target_incremental", true)
 }

--- a/core/src/test/kotlin/org/evomaster/core/output/TestSuiteOrganizerTest.kt
+++ b/core/src/test/kotlin/org/evomaster/core/output/TestSuiteOrganizerTest.kt
@@ -1,0 +1,71 @@
+package org.evomaster.core.output
+
+import org.evomaster.core.output.naming.NumberedTestCaseNamingStrategy
+import org.evomaster.core.output.naming.RestActionTestCaseUtils.getEvaluatedIndividualWith
+import org.evomaster.core.output.naming.RestActionTestCaseUtils.getRestCallAction
+import org.evomaster.core.problem.rest.HttpVerb
+import org.evomaster.core.search.Solution
+import org.junit.Test
+import org.junit.jupiter.api.Assertions.assertEquals
+
+class TestSuiteOrganizerTest {
+
+    @Test
+    fun sortedByPathSegmentFirst() {
+        val noPathSegmentInd = getEvaluatedIndividualWith(getRestCallAction("/"))
+        val onePathSegmentInd = getEvaluatedIndividualWith(getRestCallAction("/organization"))
+        val twoPathSegmentsInd = getEvaluatedIndividualWith(getRestCallAction("/organization/{name}"))
+        val individuals = mutableListOf(noPathSegmentInd, onePathSegmentInd, twoPathSegmentsInd)
+        individuals.shuffle()
+        val solution = Solution(individuals, "suitePrefix", "suiteSuffix", Termination.NONE, emptyList(), emptyList())
+
+        val sortedTestCases = SortingHelper().sort(solution, NumberedTestCaseNamingStrategy(solution))
+
+        assertEquals(sortedTestCases[0].test, noPathSegmentInd)
+        assertEquals(sortedTestCases[1].test, onePathSegmentInd)
+        assertEquals(sortedTestCases[2].test, twoPathSegmentsInd)
+    }
+
+    @Test
+    fun sortedByStatusCodeWhenEqualPathSegmentSize() {
+        val status200Ind = getEvaluatedIndividualWith(getRestCallAction("/organization"), 200)
+        val status401Ind = getEvaluatedIndividualWith(getRestCallAction("/organization"), 401)
+        val status500Ind = getEvaluatedIndividualWith(getRestCallAction("/organization"), 500)
+        val individuals = mutableListOf(status200Ind, status401Ind, status500Ind)
+        individuals.shuffle()
+        val solution = Solution(individuals, "suitePrefix", "suiteSuffix", Termination.NONE, emptyList(), emptyList())
+
+        val sortedTestCases = SortingHelper().sort(solution, NumberedTestCaseNamingStrategy(solution))
+
+        assertEquals(sortedTestCases[0].test, status500Ind)
+        assertEquals(sortedTestCases[1].test, status200Ind)
+        assertEquals(sortedTestCases[2].test, status401Ind)
+    }
+
+    @Test
+    fun sortedByMethodWhenEqualPathSegmentsAndStatusCode() {
+        val getInd = getEvaluatedIndividualWith(getRestCallAction("/organization", HttpVerb.GET))
+        val postInd = getEvaluatedIndividualWith(getRestCallAction("/organization", HttpVerb.POST))
+        val putInd = getEvaluatedIndividualWith(getRestCallAction("/organization", HttpVerb.PUT))
+        val deleteInd = getEvaluatedIndividualWith(getRestCallAction("/organization", HttpVerb.DELETE))
+        val optionsInd = getEvaluatedIndividualWith(getRestCallAction("/organization", HttpVerb.OPTIONS))
+        val patchInd = getEvaluatedIndividualWith(getRestCallAction("/organization", HttpVerb.PATCH))
+        val traceInd = getEvaluatedIndividualWith(getRestCallAction("/organization", HttpVerb.TRACE))
+        val headInd = getEvaluatedIndividualWith(getRestCallAction("/organization", HttpVerb.HEAD))
+        val individuals = mutableListOf(getInd, postInd, putInd, deleteInd, optionsInd, patchInd, traceInd, headInd)
+        individuals.shuffle()
+        val solution = Solution(individuals, "suitePrefix", "suiteSuffix", Termination.NONE, emptyList(), emptyList())
+
+        val sortedTestCases = SortingHelper().sort(solution, NumberedTestCaseNamingStrategy(solution))
+
+        assertEquals(sortedTestCases[0].test, getInd)
+        assertEquals(sortedTestCases[1].test, postInd)
+        assertEquals(sortedTestCases[2].test, putInd)
+        assertEquals(sortedTestCases[3].test, deleteInd)
+        assertEquals(sortedTestCases[4].test, optionsInd)
+        assertEquals(sortedTestCases[5].test, patchInd)
+        assertEquals(sortedTestCases[6].test, traceInd)
+        assertEquals(sortedTestCases[7].test, headInd)
+    }
+
+}

--- a/core/src/test/kotlin/org/evomaster/core/output/TestSuiteOrganizerTest.kt
+++ b/core/src/test/kotlin/org/evomaster/core/output/TestSuiteOrganizerTest.kt
@@ -1,17 +1,39 @@
 package org.evomaster.core.output
 
+import org.evomaster.core.TestUtils
 import org.evomaster.core.output.naming.NumberedTestCaseNamingStrategy
 import org.evomaster.core.output.naming.RestActionTestCaseUtils.getEvaluatedIndividualWith
 import org.evomaster.core.output.naming.RestActionTestCaseUtils.getRestCallAction
+import org.evomaster.core.output.sorting.SortingStrategy
+import org.evomaster.core.problem.api.param.Param
+import org.evomaster.core.problem.enterprise.EnterpriseActionGroup
+import org.evomaster.core.problem.enterprise.SampleType
+import org.evomaster.core.problem.graphql.GQMethodType
+import org.evomaster.core.problem.graphql.GraphQLAction
+import org.evomaster.core.problem.graphql.GraphQLIndividual
+import org.evomaster.core.problem.graphql.GraphQlCallResult
+import org.evomaster.core.problem.graphql.param.GQInputParam
 import org.evomaster.core.problem.rest.HttpVerb
+import org.evomaster.core.problem.rpc.RPCCallAction
+import org.evomaster.core.problem.rpc.RPCIndividual
+import org.evomaster.core.problem.rpc.param.RPCParam
+import org.evomaster.core.search.EvaluatedIndividual
+import org.evomaster.core.search.FitnessValue
 import org.evomaster.core.search.Solution
+import org.evomaster.core.search.gene.optional.OptionalGene
+import org.evomaster.core.search.gene.string.StringGene
 import org.junit.Test
 import org.junit.jupiter.api.Assertions.assertEquals
+import java.util.UUID
 
 class TestSuiteOrganizerTest {
 
+    companion object {
+        val sortingStrategy = SortingStrategy.TARGET_INCREMENTAL
+    }
+
     @Test
-    fun sortedByPathSegmentFirst() {
+    fun restSortedByPathSegmentFirst() {
         val noPathSegmentInd = getEvaluatedIndividualWith(getRestCallAction("/"))
         val onePathSegmentInd = getEvaluatedIndividualWith(getRestCallAction("/organization"))
         val twoPathSegmentsInd = getEvaluatedIndividualWith(getRestCallAction("/organization/{name}"))
@@ -19,7 +41,7 @@ class TestSuiteOrganizerTest {
         individuals.shuffle()
         val solution = Solution(individuals, "suitePrefix", "suiteSuffix", Termination.NONE, emptyList(), emptyList())
 
-        val sortedTestCases = SortingHelper().sort(solution, NumberedTestCaseNamingStrategy(solution))
+        val sortedTestCases = SortingHelper().sort(solution, NumberedTestCaseNamingStrategy(solution), sortingStrategy)
 
         assertEquals(sortedTestCases[0].test, noPathSegmentInd)
         assertEquals(sortedTestCases[1].test, onePathSegmentInd)
@@ -27,7 +49,7 @@ class TestSuiteOrganizerTest {
     }
 
     @Test
-    fun sortedByStatusCodeWhenEqualPathSegmentSize() {
+    fun restSortedByStatusCodeWhenEqualPathSegmentSize() {
         val status200Ind = getEvaluatedIndividualWith(getRestCallAction("/organization"), 200)
         val status401Ind = getEvaluatedIndividualWith(getRestCallAction("/organization"), 401)
         val status500Ind = getEvaluatedIndividualWith(getRestCallAction("/organization"), 500)
@@ -35,7 +57,7 @@ class TestSuiteOrganizerTest {
         individuals.shuffle()
         val solution = Solution(individuals, "suitePrefix", "suiteSuffix", Termination.NONE, emptyList(), emptyList())
 
-        val sortedTestCases = SortingHelper().sort(solution, NumberedTestCaseNamingStrategy(solution))
+        val sortedTestCases = SortingHelper().sort(solution, NumberedTestCaseNamingStrategy(solution), sortingStrategy)
 
         assertEquals(sortedTestCases[0].test, status500Ind)
         assertEquals(sortedTestCases[1].test, status200Ind)
@@ -43,7 +65,7 @@ class TestSuiteOrganizerTest {
     }
 
     @Test
-    fun sortedByMethodWhenEqualPathSegmentsAndStatusCode() {
+    fun restSortedByMethodWhenEqualPathSegmentsAndStatusCode() {
         val getInd = getEvaluatedIndividualWith(getRestCallAction("/organization", HttpVerb.GET))
         val postInd = getEvaluatedIndividualWith(getRestCallAction("/organization", HttpVerb.POST))
         val putInd = getEvaluatedIndividualWith(getRestCallAction("/organization", HttpVerb.PUT))
@@ -56,7 +78,7 @@ class TestSuiteOrganizerTest {
         individuals.shuffle()
         val solution = Solution(individuals, "suitePrefix", "suiteSuffix", Termination.NONE, emptyList(), emptyList())
 
-        val sortedTestCases = SortingHelper().sort(solution, NumberedTestCaseNamingStrategy(solution))
+        val sortedTestCases = SortingHelper().sort(solution, NumberedTestCaseNamingStrategy(solution), sortingStrategy)
 
         assertEquals(sortedTestCases[0].test, getInd)
         assertEquals(sortedTestCases[1].test, postInd)
@@ -67,5 +89,151 @@ class TestSuiteOrganizerTest {
         assertEquals(sortedTestCases[6].test, traceInd)
         assertEquals(sortedTestCases[7].test, headInd)
     }
+
+    @Test
+    fun graphSortedByMethodNameFirst() {
+        val aLetterIndividual = getGraphQLEvaluatedIndividual(GQMethodType.QUERY, "aLetterMethod")
+        val bLetterIndividual = getGraphQLEvaluatedIndividual(GQMethodType.QUERY, "bLetterMethod")
+        val cLetterIndividual = getGraphQLEvaluatedIndividual(GQMethodType.QUERY, "cLetterMethod")
+        val individuals = mutableListOf(aLetterIndividual, bLetterIndividual, cLetterIndividual)
+        individuals.shuffle()
+        val solution = Solution(individuals, "suitePrefix", "suiteSuffix", Termination.NONE, emptyList(), emptyList())
+
+        val sortedTestCases = SortingHelper().sort(solution, NumberedTestCaseNamingStrategy(solution), sortingStrategy)
+
+        assertEquals(sortedTestCases[0].test, aLetterIndividual)
+        assertEquals(sortedTestCases[1].test, bLetterIndividual)
+        assertEquals(sortedTestCases[2].test, cLetterIndividual)
+    }
+
+    @Test
+    fun graphSortedByMethodTypeWhenEqualMethodNameAndParametersSize() {
+        val paramLambda = { name: String, value: String -> getGraphQLParam(name, value) }
+        val queryOneParameterIndividual = getGraphQLEvaluatedIndividual(GQMethodType.QUERY, "myMethod", getListOfParams(1, paramLambda))
+        val queryTwoParametersIndividual = getGraphQLEvaluatedIndividual(GQMethodType.QUERY, "myMethod", getListOfParams(2, paramLambda))
+        val mutationOneParameterIndividual = getGraphQLEvaluatedIndividual(GQMethodType.MUTATION, "myMethod", getListOfParams(1, paramLambda))
+        val mutationTwoParametersIndividual = getGraphQLEvaluatedIndividual(GQMethodType.MUTATION, "myMethod", getListOfParams(2, paramLambda))
+        val individuals = mutableListOf(queryOneParameterIndividual, queryTwoParametersIndividual, mutationOneParameterIndividual, mutationTwoParametersIndividual)
+        individuals.shuffle()
+        val solution = Solution(individuals, "suitePrefix", "suiteSuffix", Termination.NONE, emptyList(), emptyList())
+
+        val sortedTestCases = SortingHelper().sort(solution, NumberedTestCaseNamingStrategy(solution), sortingStrategy)
+
+        assertEquals(sortedTestCases[0].test, queryOneParameterIndividual)
+        assertEquals(sortedTestCases[1].test, queryTwoParametersIndividual)
+        assertEquals(sortedTestCases[2].test, mutationOneParameterIndividual)
+        assertEquals(sortedTestCases[3].test, mutationTwoParametersIndividual)
+    }
+
+    @Test
+    fun graphSortedByAmountOfParametersWhenEqualMethodNameAndType() {
+        val paramLambda = { name: String, value: String -> getGraphQLParam(name, value) }
+        val oneParameterIndividual = getGraphQLEvaluatedIndividual(GQMethodType.QUERY, "myMethod", getListOfParams(1, paramLambda))
+        val twoParametersIndividual = getGraphQLEvaluatedIndividual(GQMethodType.QUERY, "myMethod", getListOfParams(2, paramLambda))
+        val threeParametersIndividual = getGraphQLEvaluatedIndividual(GQMethodType.QUERY, "myMethod", getListOfParams(3, paramLambda))
+        val individuals = mutableListOf(oneParameterIndividual, twoParametersIndividual, threeParametersIndividual)
+        individuals.shuffle()
+        val solution = Solution(individuals, "suitePrefix", "suiteSuffix", Termination.NONE, emptyList(), emptyList())
+
+        val sortedTestCases = SortingHelper().sort(solution, NumberedTestCaseNamingStrategy(solution), sortingStrategy)
+
+        assertEquals(sortedTestCases[0].test, oneParameterIndividual)
+        assertEquals(sortedTestCases[1].test, twoParametersIndividual)
+        assertEquals(sortedTestCases[2].test, threeParametersIndividual)
+    }
+
+    @Test
+    fun rpcSortedByClassNameFirst() {
+        val aFakeClassIndividual = getRPCEvaluatedIndividual("aFakeInterfaceClass:fakeInterfaceMethod")
+        val bFakeClassIndividual = getRPCEvaluatedIndividual("bFakeInterfaceClass:fakeInterfaceMethod")
+        val cFakeClassIndividual = getRPCEvaluatedIndividual("cFakeInterfaceClass:fakeInterfaceMethod")
+        val individuals = mutableListOf(aFakeClassIndividual, bFakeClassIndividual, cFakeClassIndividual)
+        individuals.shuffle()
+        val solution = Solution(individuals, "suitePrefix", "suiteSuffix", Termination.NONE, emptyList(), emptyList())
+
+        val sortedTestCases = SortingHelper().sort(solution, NumberedTestCaseNamingStrategy(solution), sortingStrategy)
+
+        assertEquals(sortedTestCases[0].test, aFakeClassIndividual)
+        assertEquals(sortedTestCases[1].test, bFakeClassIndividual)
+        assertEquals(sortedTestCases[2].test, cFakeClassIndividual)
+    }
+
+    @Test
+    fun rpcSortedByMethodNameWhenEqualClassName() {
+        val aFakeMethodIndividual = getRPCEvaluatedIndividual("fakeInterfaceClass:aFakeInterfaceMethod")
+        val bFakeMethodIndividual = getRPCEvaluatedIndividual("fakeInterfaceClass:bFakeInterfaceMethod")
+        val cFakeMethodIndividual = getRPCEvaluatedIndividual("fakeInterfaceClass:cFakeInterfaceMethod")
+        val individuals = mutableListOf(aFakeMethodIndividual, bFakeMethodIndividual, cFakeMethodIndividual)
+        individuals.shuffle()
+        val solution = Solution(individuals, "suitePrefix", "suiteSuffix", Termination.NONE, emptyList(), emptyList())
+
+        val sortedTestCases = SortingHelper().sort(solution, NumberedTestCaseNamingStrategy(solution), sortingStrategy)
+
+        assertEquals(sortedTestCases[0].test, aFakeMethodIndividual)
+        assertEquals(sortedTestCases[1].test, bFakeMethodIndividual)
+        assertEquals(sortedTestCases[2].test, cFakeMethodIndividual)
+    }
+
+    @Test
+    fun rpcSortedByAmountOfParametersWhenClassAndMethodNames() {
+        val paramLambda = { name: String, value: String -> getRPCParam(name, value) }
+        val oneParameterIndividual = getRPCEvaluatedIndividual("fakeInterfaceClass:fakeInterfaceMethod", getListOfParams(1, paramLambda))
+        val twoParametersIndividual = getRPCEvaluatedIndividual("fakeInterfaceClass:fakeInterfaceMethod", getListOfParams(2, paramLambda))
+        val threeParametersIndividual = getRPCEvaluatedIndividual("fakeInterfaceClass:fakeInterfaceMethod", getListOfParams(3, paramLambda))
+        val individuals = mutableListOf(oneParameterIndividual, twoParametersIndividual, threeParametersIndividual)
+        individuals.shuffle()
+        val solution = Solution(individuals, "suitePrefix", "suiteSuffix", Termination.NONE, emptyList(), emptyList())
+
+        val sortedTestCases = SortingHelper().sort(solution, NumberedTestCaseNamingStrategy(solution), sortingStrategy)
+
+        assertEquals(sortedTestCases[0].test, oneParameterIndividual)
+        assertEquals(sortedTestCases[1].test, twoParametersIndividual)
+        assertEquals(sortedTestCases[2].test, threeParametersIndividual)
+    }
+
+    private fun getGraphQLEvaluatedIndividual(query: GQMethodType, methodName: String, params: MutableList<Param> = mutableListOf()): EvaluatedIndividual<GraphQLIndividual> {
+        val action = GraphQLAction(methodName, methodName, query, params)
+
+        val actions = mutableListOf<EnterpriseActionGroup<*>>()
+        actions.add(EnterpriseActionGroup(mutableListOf(action), GraphQLAction::class.java))
+
+        val individual = GraphQLIndividual(SampleType.RANDOM, actions)
+        TestUtils.doInitializeIndividualForTesting(individual)
+
+        val results = listOf(GraphQlCallResult(action.getLocalId()))
+        return EvaluatedIndividual(FitnessValue(0.0), individual, results)
+    }
+
+    private fun getListOfParams(amount: Int, paramFunction: (name: String, value: String) -> Param): MutableList<Param> {
+        val params = mutableListOf<Param>()
+        for (i in 0..amount) {
+            val name = UUID.randomUUID().toString()
+            val value = UUID.randomUUID().toString()
+            params.add(paramFunction(name, value))
+        }
+        return params
+    }
+
+    private fun getGraphQLParam(name: String, value: String): GQInputParam {
+        val op = OptionalGene(name, StringGene(name, value))
+        return GQInputParam(name, op)
+    }
+
+    private fun getRPCEvaluatedIndividual(interfaceId: String, params: MutableList<Param> = mutableListOf()): EvaluatedIndividual<RPCIndividual> {
+        val action = RPCCallAction(interfaceId, "${interfaceId}_0", params, null, null)
+        val externalAction = EvaluatedIndividualBuilder.buildFakeDbExternalServiceAction(1).plus(EvaluatedIndividualBuilder.buildFakeRPCExternalServiceAction(1))
+
+        val individual = RPCIndividual(SampleType.RANDOM, actions=mutableListOf(action), externalServicesActions = mutableListOf(externalAction))
+        TestUtils.doInitializeIndividualForTesting(individual)
+
+        val results = listOf(GraphQlCallResult(action.getLocalId()))
+        return EvaluatedIndividual(FitnessValue(0.0), individual, results)
+    }
+
+    private fun getRPCParam(name: String, value: String): RPCParam {
+        val op = OptionalGene(name, StringGene(name, value))
+        return RPCParam(name, op)
+    }
+
 
 }

--- a/docs/options.md
+++ b/docs/options.md
@@ -205,6 +205,7 @@ There are 3 types of options:
 |`taintOnSampling`| __Boolean__. Whether input tracking is used on sampling time, besides mutation time. *Default value*: `true`.|
 |`taintRemoveProbability`| __Double__. Probability of removing a tainted value during mutation. *Constraints*: `probability 0.0-1.0`. *Default value*: `0.5`.|
 |`tcpTimeoutMs`| __Int__. Number of milliseconds we are going to wait to get a response on a TCP connection, e.g., when making HTTP calls to a Web API. *Default value*: `30000`.|
+|`testCaseSortingStrategy`| __Enum__. Specify the test case sorting strategy. *Valid values*: `COVERED_TARGETS, PATH_INCREMENTAL`. *Default value*: `COVERED_TARGETS`.|
 |`testSuiteFileName`| __String__. DEPRECATED. Rather use _outputFilePrefix_ and _outputFileSuffix_. *Default value*: `""`.|
 |`testSuiteSplitType`| __Enum__. Instead of generating a single test file, it could be split in several files, according to different strategies. *Valid values*: `NONE, FAULTS`. *Default value*: `FAULTS`.|
 |`tournamentSize`| __Int__. Number of elements to consider in a Tournament Selection (if any is used in the search algorithm). *Constraints*: `min=1.0`. *Default value*: `10`.|

--- a/docs/options.md
+++ b/docs/options.md
@@ -205,7 +205,7 @@ There are 3 types of options:
 |`taintOnSampling`| __Boolean__. Whether input tracking is used on sampling time, besides mutation time. *Default value*: `true`.|
 |`taintRemoveProbability`| __Double__. Probability of removing a tainted value during mutation. *Constraints*: `probability 0.0-1.0`. *Default value*: `0.5`.|
 |`tcpTimeoutMs`| __Int__. Number of milliseconds we are going to wait to get a response on a TCP connection, e.g., when making HTTP calls to a Web API. *Default value*: `30000`.|
-|`testCaseSortingStrategy`| __Enum__. Specify the test case sorting strategy. *Valid values*: `COVERED_TARGETS, PATH_INCREMENTAL`. *Default value*: `COVERED_TARGETS`.|
+|`testCaseSortingStrategy`| __Enum__. Specify the test case sorting strategy. *Valid values*: `COVERED_TARGETS, TARGET_INCREMENTAL`. *Default value*: `COVERED_TARGETS`.|
 |`testSuiteFileName`| __String__. DEPRECATED. Rather use _outputFilePrefix_ and _outputFileSuffix_. *Default value*: `""`.|
 |`testSuiteSplitType`| __Enum__. Instead of generating a single test file, it could be split in several files, according to different strategies. *Valid values*: `NONE, FAULTS`. *Default value*: `FAULTS`.|
 |`tournamentSize`| __Int__. Number of elements to consider in a Tournament Selection (if any is used in the search algorithm). *Constraints*: `min=1.0`. *Default value*: `10`.|

--- a/e2e-tests/spring-rest-openapi-v2/src/test/java/org/evomaster/e2etests/spring/examples/sort/SortEMTest.java
+++ b/e2e-tests/spring-rest-openapi-v2/src/test/java/org/evomaster/e2etests/spring/examples/sort/SortEMTest.java
@@ -4,6 +4,7 @@ import org.evomaster.core.output.TestCase;
 import org.evomaster.core.output.TestSuiteOrganizer;
 import org.evomaster.core.output.naming.NumberedTestCaseNamingStrategy;
 import org.evomaster.core.output.naming.TestCaseNamingStrategy;
+import org.evomaster.core.output.sorting.SortingStrategy;
 import org.evomaster.core.problem.rest.HttpVerb;
 import org.evomaster.core.problem.rest.RestCallResult;
 import org.evomaster.core.problem.rest.RestIndividual;
@@ -46,7 +47,7 @@ public class SortEMTest extends NRTestBase {
 
                     TestCaseNamingStrategy namingStrategy = new NumberedTestCaseNamingStrategy(solution);
 
-                    List<TestCase> tclist = organizer.sortTests(solution, namingStrategy);
+                    List<TestCase> tclist = organizer.sortTests(solution, namingStrategy, SortingStrategy.COVERED_TARGETS);
 
                     //Iterator<TestCase> iterator = tclist.iterator();
                     //TestCase current, previous = iterator.next();


### PR DESCRIPTION
# What's in the box:
- Sorting strategy divided into two options: `COVERED_TARGETS` (current one), `TARGET_INCREMENTAL` (new one)
- `COVERED_TARGETS` will be set as default strategy
- `TARGET_INCREMENTAL` focuses on tests being organized in an incremental criteria:
    - REST: Paths with least levels first, then status codes (500 first, then from 200..), last HTTP verb  
    - GraphQL: Method name first, method type second (`query`/`mutation`), amount of parameters
    - RPC: Tested class name, tested method name, amount of parameters