### PR TITLE
Test case names use amount of digits to calculate length

### DIFF
--- a/core/src/main/kotlin/org/evomaster/core/output/naming/ActionTestCaseNamingStrategy.kt
+++ b/core/src/main/kotlin/org/evomaster/core/output/naming/ActionTestCaseNamingStrategy.kt
@@ -94,7 +94,8 @@ abstract class ActionTestCaseNamingStrategy(
     }
 
     protected fun namePrefixChars(): Int {
-        return "test_".length + testCasesSize + 1
+        val digitsUsedForTestNumbering = testCasesSize.toString().length
+        return "test_".length + digitsUsedForTestNumbering + 1
     }
 
     protected fun addNameTokensIfAllowed(nameTokens: MutableList<String>, targetStrings: List<String>, remainingNameChars: Int): Int {

--- a/core/src/test/kotlin/org/evomaster/core/output/naming/RestActionNamingStrategyTest.kt
+++ b/core/src/test/kotlin/org/evomaster/core/output/naming/RestActionNamingStrategyTest.kt
@@ -9,9 +9,12 @@ import org.evomaster.core.output.naming.RestActionTestCaseUtils.getRestCallActio
 import org.evomaster.core.output.naming.rest.RestActionTestCaseNamingStrategy
 import org.evomaster.core.problem.enterprise.DetectedFault
 import org.evomaster.core.problem.rest.*
+import org.evomaster.core.search.EvaluatedIndividual
 import org.evomaster.core.search.Solution
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
+import java.util.*
 import java.util.Collections.singletonList
 import javax.ws.rs.core.MediaType
 
@@ -262,6 +265,22 @@ open class RestActionNamingStrategyTest {
 
         assertEquals(1, testCases.size)
         assertEquals("test_0_postOnItemsReturns200UsingSqlWireMock", testCases[0].name)
+    }
+
+    @Test
+    fun testNameLengthUsesNumberLengthNotNumberValue() {
+        val restAction = getRestCallAction()
+        val inds = mutableListOf<EvaluatedIndividual<RestIndividual>>()
+        for (i in 1..10) {
+            inds.add(getEvaluatedIndividualWith(restAction))
+        }
+        val solution = Solution(Collections.unmodifiableList(inds), "suitePrefix", "suiteSuffix", Termination.NONE, emptyList(), emptyList())
+
+        val namingStrategy = RestActionTestCaseNamingStrategy(solution, javaFormatter, NO_QUERY_PARAMS_IN_NAME, 20)
+        val testCases = namingStrategy.getTestCases()
+
+        assertEquals(10, testCases.size)
+        assertTrue(testCases.stream().allMatch { it.name.length > "test_10".length })
     }
 
 }


### PR DESCRIPTION
# What's in the box
Simple (and silly) fix. The amount of tests were being used to calculate the remaining available chars for a test case name. Therefore, since the default length of a test case is 80 chars, whenever the suite was big enough (eg. 90 tests), the calculation was `"test_".length + 90 + 1`, this adds to 96, which when comparing to the 80 available chars, meant that no extra information could be added to the test case name.
What we were actually looking for is `"test_".length + 2 + 1`, since the number 90 uses 2 chars in naming