### PR TITLE
Add not supported types for smtlib generator

### DIFF
--- a/core/src/main/kotlin/org/evomaster/core/solver/SMTConditionVisitor.kt
+++ b/core/src/main/kotlin/org/evomaster/core/solver/SMTConditionVisitor.kt
@@ -149,7 +149,11 @@ class SMTConditionVisitor(
             .map {
                 AssertSMTNode(EqualsAssertion(listOf(left, asLiteral(it))))
             }
-        return AssertSMTNode(OrAssertion(conditions.map { it.assertion }))
+        return if (conditions.size == 1) {
+            conditions[0]
+        } else {
+            AssertSMTNode(OrAssertion(conditions.map { it.assertion }))
+        }
     }
 
     private fun asLiteral(expression: SqlCondition?): String {

--- a/core/src/main/kotlin/org/evomaster/core/solver/SmtLibGenerator.kt
+++ b/core/src/main/kotlin/org/evomaster/core/solver/SmtLibGenerator.kt
@@ -427,16 +427,18 @@ class SmtLibGenerator(private val schema: DbInfoDto, private val numberOfRows: I
         if (sqlQuery is Select) { // TODO: Handle other queries
             val plainSelect = sqlQuery.selectBody as PlainSelect
             val fromItem = plainSelect.fromItem
-            val tableName = getTableName(fromItem)
-            val alias = fromItem.alias?.name ?: tableName
-            tableAliasMap[alias] = tableName
+            if (fromItem != null) {
+                val tableName = getTableName(fromItem)
+                val alias = fromItem.alias?.name ?: tableName
+                tableAliasMap[alias] = tableName
 
-            val joins = plainSelect.joins
-            if (joins != null) {
-                for (join in joins) {
-                    val joinAlias = join.rightItem.alias?.name ?: join.rightItem.toString()
-                    val joinName = getTableName(join.rightItem)
-                    tableAliasMap[joinAlias] = joinName
+                val joins = plainSelect.joins
+                if (joins != null) {
+                    for (join in joins) {
+                        val joinAlias = join.rightItem.alias?.name ?: join.rightItem.toString()
+                        val joinName = getTableName(join.rightItem)
+                        tableAliasMap[joinAlias] = joinName
+                    }
                 }
             }
         }

--- a/core/src/main/kotlin/org/evomaster/core/solver/SmtLibGenerator.kt
+++ b/core/src/main/kotlin/org/evomaster/core/solver/SmtLibGenerator.kt
@@ -425,7 +425,7 @@ class SmtLibGenerator(private val schema: DbInfoDto, private val numberOfRows: I
         if (sqlQuery is Select) { // TODO: Handle other queries
             val plainSelect = sqlQuery.selectBody as PlainSelect
             val fromItem = plainSelect.fromItem
-            val tableName = (fromItem as net.sf.jsqlparser.schema.Table).name
+            val tableName = getTableName(fromItem)
             val alias = fromItem.alias?.name ?: tableName
             tableAliasMap[alias] = tableName
 
@@ -433,13 +433,16 @@ class SmtLibGenerator(private val schema: DbInfoDto, private val numberOfRows: I
             if (joins != null) {
                 for (join in joins) {
                     val joinAlias = join.rightItem.alias?.name ?: join.rightItem.toString()
-                    val joinName = (join.rightItem as net.sf.jsqlparser.schema.Table).name
+                    val joinName = getTableName(join.rightItem)
                     tableAliasMap[joinAlias] = joinName
                 }
             }
         }
         return tableAliasMap
     }
+
+    private fun getTableName(fromItem: FromItem?): String =
+        (fromItem as Table).getName()
 
     /**
      * Appends value checking constraints to the SMT-LIB only from the tables mentioned in the select

--- a/core/src/main/kotlin/org/evomaster/core/solver/SmtLibGenerator.kt
+++ b/core/src/main/kotlin/org/evomaster/core/solver/SmtLibGenerator.kt
@@ -1,6 +1,8 @@
 package org.evomaster.core.solver
 
+import net.sf.jsqlparser.schema.Table
 import net.sf.jsqlparser.statement.Statement
+import net.sf.jsqlparser.statement.select.FromItem
 import net.sf.jsqlparser.statement.select.PlainSelect
 import net.sf.jsqlparser.statement.select.Select
 import net.sf.jsqlparser.util.TablesNamesFinder

--- a/core/src/main/kotlin/org/evomaster/core/solver/SmtLibGenerator.kt
+++ b/core/src/main/kotlin/org/evomaster/core/solver/SmtLibGenerator.kt
@@ -511,8 +511,10 @@ class SmtLibGenerator(private val schema: DbInfoDto, private val numberOfRows: I
             "FLOAT" to "Real",
             "DOUBLE" to "Real",
             "DECIMAL" to "Real",
+            "REAL" to "Real",
             "CHARACTER VARYING" to "String",
             "CHAR" to "String",
+            "VARCHAR" to "String",
             "CHARACTER LARGE OBJECT" to "String",
             "BOOLEAN" to "String", // TODO: Check this
         )

--- a/solver/src/main/java/org/evomaster/solver/smtlib/SMTResultParser.java
+++ b/solver/src/main/java/org/evomaster/solver/smtlib/SMTResultParser.java
@@ -55,7 +55,8 @@ public class SMTResultParser {
                 continue;
             }
 
-            buffer.append(line.trim()).append(" ");
+            String sanitizedLine = line.trim().replaceAll("\\(-\\s+(\\d+)\\)", "(-$1)"); // Remove spaces for negative numbers, example: (- 321)
+            buffer.append(sanitizedLine).append(" ");
 
             // Check if the buffer contains a complete expression
             Matcher composedMatcher = composedTypePattern.matcher(buffer.toString());
@@ -100,6 +101,14 @@ public class SMTResultParser {
      * @return an SMTLibValue representing the parsed value
      */
     private static SMTLibValue parseValue(String value) {
+        if (value.startsWith("(")) {
+            // If it is a negative number in parentheses
+            value = value.substring(1).trim(); // Remove parentheses
+        }
+        if (value.endsWith(")")) {
+            // If it is a negative number in parentheses
+            value = value.substring(0, value.length() - 1).trim(); // Remove parentheses
+        }
         if (value.startsWith("\"") && value.endsWith("\"")) {
             // If it is a string
             return new StringValue(value.substring(1, value.length() - 1)); // Remove quotes

--- a/solver/src/test/java/org/evomaster/solver/smtlib/SMTResultParserTest.java
+++ b/solver/src/test/java/org/evomaster/solver/smtlib/SMTResultParserTest.java
@@ -148,4 +148,54 @@ public class SMTResultParserTest {
         assertTrue(users2.getField("POINTS") instanceof LongValue);
         assertEquals(7, ((LongValue) users2.getField("POINTS")).getValue());
     }
+
+    
+    @Test
+    public void testNegativeLong() {
+        String response = "sat\n" +
+                "((documents_specs1 (id-first_page-last_page-printing_schema-document_id 5 6 7 8 (- 4194297))))\n" +
+                "((printing_schemas1 (id-binding_specs-cover_specs-is_deleted-pschema_name-paper_specs-consumer_id\n" +
+                "  8\n" +
+                "  \"true\"\n" +
+                "  \"true\"\n" +
+                "  \"true\"\n" +
+                "  \"true\"\n" +
+                "  \"true\"\n" +
+                "  2)))\n";
+
+        Map<String, SMTLibValue> result = SMTResultParser.parseZ3Response(response);
+        assertEquals(2, result.size());
+
+        assertTrue(result.get("documents_specs1") instanceof StructValue);
+        StructValue documents_specs1 = (StructValue) result.get("documents_specs1");
+        assertEquals(5, documents_specs1.getFields().size());
+        assertTrue(documents_specs1.getField("ID") instanceof LongValue);
+        assertEquals(5, ((LongValue) documents_specs1.getField("ID")).getValue());
+        assertTrue(documents_specs1.getField("FIRST_PAGE") instanceof LongValue);
+        assertEquals(6, ((LongValue) documents_specs1.getField("FIRST_PAGE")).getValue());
+        assertTrue(documents_specs1.getField("LAST_PAGE") instanceof LongValue);
+        assertEquals(7, ((LongValue) documents_specs1.getField("LAST_PAGE")).getValue());
+        assertTrue(documents_specs1.getField("PRINTING_SCHEMA") instanceof LongValue);
+        assertEquals(8, ((LongValue) documents_specs1.getField("PRINTING_SCHEMA")).getValue());
+        assertTrue(documents_specs1.getField("DOCUMENT_ID") instanceof LongValue);
+        assertEquals(-4194297, ((LongValue) documents_specs1.getField("DOCUMENT_ID")).getValue());
+
+        assertTrue(result.get("printing_schemas1") instanceof StructValue);
+        StructValue printing_schemas1 = (StructValue) result.get("printing_schemas1");
+        assertEquals(7, printing_schemas1.getFields().size());
+        assertTrue(printing_schemas1.getField("ID") instanceof LongValue);
+        assertEquals(8, ((LongValue) printing_schemas1.getField("ID")).getValue());
+        assertTrue(printing_schemas1.getField("BINDING_SPECS") instanceof StringValue);
+        assertEquals("true", ((StringValue) printing_schemas1.getField("BINDING_SPECS")).getValue());
+        assertTrue(printing_schemas1.getField("COVER_SPECS") instanceof StringValue);
+        assertEquals("true", ((StringValue) printing_schemas1.getField("COVER_SPECS")).getValue());
+        assertTrue(printing_schemas1.getField("IS_DELETED") instanceof StringValue);
+        assertEquals("true", ((StringValue) printing_schemas1.getField("IS_DELETED")).getValue());
+        assertTrue(printing_schemas1.getField("PSCHEMA_NAME") instanceof StringValue);
+        assertEquals("true", ((StringValue) printing_schemas1.getField("PSCHEMA_NAME")).getValue());
+        assertTrue(printing_schemas1.getField("PAPER_SPECS") instanceof StringValue);
+        assertEquals("true", ((StringValue) printing_schemas1.getField("PAPER_SPECS")).getValue());
+        assertTrue(printing_schemas1.getField("CONSUMER_ID") instanceof LongValue);
+        assertEquals(2, ((LongValue) printing_schemas1.getField("CONSUMER_ID")).getValue());
+    }
 }


### PR DESCRIPTION
1. The types map was missing "REAL" and "VARCHAR", the type name depends on the database used.
2. Fix get table name
3. Avoid creating an OrAssertion when only 1 assertion
4. Fix parsing negative numbers
5. Fix getting alias from null tables