### PR TITLE
Fixed issue when attempting to disambiguate paths at root level

### DIFF
--- a/core/src/main/kotlin/org/evomaster/core/output/naming/rest/PathAmbiguitySolver.kt
+++ b/core/src/main/kotlin/org/evomaster/core/output/naming/rest/PathAmbiguitySolver.kt
@@ -19,13 +19,22 @@ class PathAmbiguitySolver : AmbiguitySolver {
         val lastPath = restAction.path
         val lastPathQualifier = getPath(lastPath.nameQualifier)
 
+        val candidateTokens = mutableListOf<String>()
+
+        if (!lastPath.isRoot()) {
+            candidateTokens.add(getParentPath(lastPath))
+        }
+        candidateTokens.add(lastPathQualifier)
+
+        return if (canAddNameTokens(candidateTokens, remainingNameChars)) candidateTokens else listOf(lastPathQualifier)
+    }
+
+    private fun getParentPath(lastPath: RestPath): String {
         var parentPath = lastPath.parentPath()
         if (lastPath.isLastElementAParameter()) {
             parentPath = parentPath.parentPath()
         }
-        val candidateTokens = listOf(getParentPathQualifier(parentPath), lastPathQualifier)
-
-        return if (canAddNameTokens(candidateTokens, remainingNameChars)) candidateTokens else listOf(lastPathQualifier)
+        return getParentPathQualifier(parentPath)
     }
 
     /*

--- a/core/src/test/kotlin/org/evomaster/core/output/naming/TestCaseDisambiguationTest.kt
+++ b/core/src/test/kotlin/org/evomaster/core/output/naming/TestCaseDisambiguationTest.kt
@@ -288,4 +288,35 @@ class TestCaseDisambiguationTest {
         assertEquals("test_1_getOnLanguagesWithQueryParamEmptyNameReturnsEmpty", testCases[1].name)
     }
 
+    @Test
+    fun noDisambiguationWhenMoreThanOneIndividualAtRootLevel() {
+        val simpleIndividual = getEvaluatedIndividualWith(getRestCallAction("/"))
+        val emptyStringIndividual = getEvaluatedIndividualWith(getRestCallAction("/"))
+
+        val solution = Solution(mutableListOf(simpleIndividual, emptyStringIndividual), "suitePrefix", "suiteSuffix", Termination.NONE, emptyList(), emptyList())
+
+        val namingStrategy = RestActionTestCaseNamingStrategy(solution, javaFormatter, QUERY_PARAMS_IN_NAME, MAX_NAME_LENGTH)
+        val testCases = namingStrategy.getTestCases()
+
+        assertEquals(2, testCases.size)
+        assertEquals("test_0_getOnRootReturnsEmpty", testCases[0].name)
+        assertEquals("test_1_getOnRootReturnsEmpty", testCases[1].name)
+    }
+
+    @Test
+    fun onlyQueryParamsDisambiguationWhenBothInRootPath() {
+        val simpleIndividual = getEvaluatedIndividualWith(getRestCallAction("/"))
+        val emptyQPIndividual = getEvaluatedIndividualWith(getRestCallAction("/", parameters = mutableListOf(getStringQueryParam("name", false))))
+        ensureGeneValue(emptyQPIndividual, "name", "")
+
+        val solution = Solution(mutableListOf(simpleIndividual, emptyQPIndividual), "suitePrefix", "suiteSuffix", Termination.NONE, emptyList(), emptyList())
+
+        val namingStrategy = RestActionTestCaseNamingStrategy(solution, javaFormatter, QUERY_PARAMS_IN_NAME, MAX_NAME_LENGTH)
+        val testCases = namingStrategy.getTestCases()
+
+        assertEquals(2, testCases.size)
+        assertEquals("test_0_getOnRootReturnsEmpty", testCases[0].name)
+        assertEquals("test_1_getOnRootWithQueryParamEmptyNameReturnsEmpty", testCases[1].name)
+    }
+
 }


### PR DESCRIPTION
When two or more tests were directed at `/` and no query parameters were involved, EM attempted to retrieve the parent path of `/`, which failed. This has now been fixed and tests added for scenarios with and without query parameters.