### PR TITLE
Adding unit testing for DTO generation

### DIFF
--- a/core/src/main/kotlin/org/evomaster/core/output/dto/DtoField.kt
+++ b/core/src/main/kotlin/org/evomaster/core/output/dto/DtoField.kt
@@ -3,4 +3,27 @@ package org.evomaster.core.output.dto
 class DtoField(
     val name: String,
     val type: String,
-)
+) {
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        other as DtoField
+
+        if (name != other.name) return false
+        if (type != other.type) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = name.hashCode()
+        result = 31 * result + type.hashCode()
+        return result
+    }
+
+    override fun toString(): String {
+        return "$name:$type"
+    }
+}

--- a/core/src/main/kotlin/org/evomaster/core/output/dto/DtoWriter.kt
+++ b/core/src/main/kotlin/org/evomaster/core/output/dto/DtoWriter.kt
@@ -66,9 +66,10 @@ class DtoWriter {
 
     private fun getDtoFromObject(gene: ObjectGene, actionName: String) {
         // TODO: Determine strategy for objects that are not defined as a component and do not have a name
+        // TODO: consider an inline schema using more than one possible component: any/one/allOf[object,object]
         val dtoName = gene.refType?:TestWriterUtils.safeVariableName(actionName)
         val dtoClass = DtoClass(dtoName)
-        // TODO: add suport for additionalFields
+        // TODO: add support for additionalFields
         gene.fixedFields.forEach { field ->
             try {
                 val wrappedGene = GeneUtils.getWrappedValueGene(field)

--- a/core/src/main/kotlin/org/evomaster/core/output/dto/DtoWriter.kt
+++ b/core/src/main/kotlin/org/evomaster/core/output/dto/DtoWriter.kt
@@ -1,5 +1,6 @@
 package org.evomaster.core.output.dto
 
+import com.google.common.annotations.VisibleForTesting
 import org.evomaster.core.output.OutputFormat
 import org.evomaster.core.output.TestWriterUtils
 import org.evomaster.core.problem.rest.param.BodyParam
@@ -30,7 +31,7 @@ import java.nio.file.Path
  * Using DTOs provides a major advantage towards code readability and sustainability. It is more flexible and scales
  * better.
  */
-object DtoWriter {
+class DtoWriter {
 
     private val log: Logger = LoggerFactory.getLogger(DtoWriter::class.java)
 
@@ -52,7 +53,7 @@ object DtoWriter {
 
     private fun getDtos(actionDefinitions: List<Action>) {
         actionDefinitions.forEach { action ->
-        action.getViewOfChildren().find { it is BodyParam }
+            action.getViewOfChildren().find { it is BodyParam }
             .let {
                 val primaryGene = GeneUtils.getWrappedValueGene((it as BodyParam).primaryGene())
                 // TODO: Payloads could also be json arrays, analyze ArrayGene
@@ -102,8 +103,13 @@ object DtoWriter {
             is DateTimeGene -> "String"
             is RegexGene -> "String"
             is BooleanGene -> "Boolean"
-            is ObjectGene -> StringUtils.capitalization(fieldName)
+            is ObjectGene -> field.refType?:StringUtils.capitalization(fieldName)
             else -> throw Exception("Not supported gene at the moment: ${field?.javaClass?.simpleName}")
         })
+    }
+
+    @VisibleForTesting
+    internal fun getCollectedDtos() : Map<String, DtoClass> {
+        return dtoCollector
     }
 }

--- a/core/src/main/kotlin/org/evomaster/core/output/dto/DtoWriter.kt
+++ b/core/src/main/kotlin/org/evomaster/core/output/dto/DtoWriter.kt
@@ -109,6 +109,9 @@ class DtoWriter {
         })
     }
 
+    /**
+     * @return collected DTOs by the DTO writer. Only for testing, otherwise we're breaking encapsulation.
+     */
     @VisibleForTesting
     internal fun getCollectedDtos() : Map<String, DtoClass> {
         return dtoCollector

--- a/core/src/main/kotlin/org/evomaster/core/output/service/TestSuiteWriter.kt
+++ b/core/src/main/kotlin/org/evomaster/core/output/service/TestSuiteWriter.kt
@@ -223,7 +223,7 @@ class TestSuiteWriter {
     fun writeDtos(solutionFilename: String) {
         val testSuitePath = getTestSuitePath(TestSuiteFileName(solutionFilename), config).parent
         val restSampler = sampler as AbstractRestSampler
-        DtoWriter.write(testSuitePath, config.outputFormat, restSampler.getActionDefinitions())
+        DtoWriter().write(testSuitePath, config.outputFormat, restSampler.getActionDefinitions())
     }
 
     private fun handleResetDatabaseInput(solution: Solution<*>): String {

--- a/core/src/test/kotlin/org/evomaster/core/output/dto/DtoWriterTest.kt
+++ b/core/src/test/kotlin/org/evomaster/core/output/dto/DtoWriterTest.kt
@@ -13,14 +13,13 @@ import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
-import java.nio.file.Files
 import java.nio.file.Path
 import java.nio.file.Paths
 
 class DtoWriterTest {
 
     companion object {
-        val tmpTestSuitePath: Path = Paths.get(Files.createTempDirectory("dto-writer-test").toUri())
+        val outputTestSuitePath: Path = Paths.get("./target/dto-writer-test")
         val outputFormat = OutputFormat.JAVA_JUNIT_4
 
         val config = EMConfig().apply {
@@ -45,14 +44,14 @@ class DtoWriterTest {
 
         supportedOutputFormats.forEach { outputFormat ->
             val dtoWriter = DtoWriter()
-            dtoWriter.write(tmpTestSuitePath, outputFormat, actionCluster.values.map { it.copy() })
+            dtoWriter.write(outputTestSuitePath, outputFormat, actionCluster.values.map { it.copy() })
             assertTrue(dtoWriter.getCollectedDtos().isNotEmpty())
         }
 
         unsupportedOutputFormats.forEach { outputFormat ->
             assertThrows(IllegalStateException::class.java, {
                 val dtoWriter = DtoWriter()
-                dtoWriter.write(tmpTestSuitePath, outputFormat, actionCluster.values.map { it.copy() })
+                dtoWriter.write(outputTestSuitePath, outputFormat, actionCluster.values.map { it.copy() })
             })
         }
     }
@@ -61,7 +60,7 @@ class DtoWriterTest {
     fun emptyActionListReturnsNoDtos() {
         val dtoWriter = DtoWriter()
 
-        dtoWriter.write(tmpTestSuitePath, outputFormat, emptyList())
+        dtoWriter.write(outputTestSuitePath, outputFormat, emptyList())
 
         assertTrue(dtoWriter.getCollectedDtos().isEmpty())
     }
@@ -71,7 +70,7 @@ class DtoWriterTest {
         val dtoWriter = DtoWriter()
         val actionCluster = initRestSchema("/swagger/dto-writer/primitiveTypes.yaml")
 
-        dtoWriter.write(tmpTestSuitePath, outputFormat, actionCluster.values.map { it.copy() })
+        dtoWriter.write(outputTestSuitePath, outputFormat, actionCluster.values.map { it.copy() })
 
         val collectedDtos = dtoWriter.getCollectedDtos()
         assertEquals(collectedDtos.size, 1)
@@ -98,7 +97,7 @@ class DtoWriterTest {
         val dtoWriter = DtoWriter()
         val actionCluster = initRestSchema("/swagger/dto-writer/childObjectInline.yaml")
 
-        dtoWriter.write(tmpTestSuitePath, outputFormat, actionCluster.values.map { it.copy() })
+        dtoWriter.write(outputTestSuitePath, outputFormat, actionCluster.values.map { it.copy() })
 
         val collectedDtos = dtoWriter.getCollectedDtos()
         assertEquals(collectedDtos.size, 2)
@@ -122,7 +121,7 @@ class DtoWriterTest {
         val dtoWriter = DtoWriter()
         val actionCluster = initRestSchema("/swagger/dto-writer/simpleComponents.yaml")
 
-        dtoWriter.write(tmpTestSuitePath, outputFormat, actionCluster.values.map { it.copy() })
+        dtoWriter.write(outputTestSuitePath, outputFormat, actionCluster.values.map { it.copy() })
 
         val collectedDtos = dtoWriter.getCollectedDtos()
         assertEquals(collectedDtos.size, 2)
@@ -144,7 +143,7 @@ class DtoWriterTest {
         val dtoWriter = DtoWriter()
         val actionCluster = initRestSchema("/swagger/dto-writer/childObjectComponent.yaml")
 
-        dtoWriter.write(tmpTestSuitePath, outputFormat, actionCluster.values.map { it.copy() })
+        dtoWriter.write(outputTestSuitePath, outputFormat, actionCluster.values.map { it.copy() })
 
         val collectedDtos = dtoWriter.getCollectedDtos()
         assertEquals(collectedDtos.size, 2)

--- a/core/src/test/kotlin/org/evomaster/core/output/dto/DtoWriterTest.kt
+++ b/core/src/test/kotlin/org/evomaster/core/output/dto/DtoWriterTest.kt
@@ -1,0 +1,176 @@
+package org.evomaster.core.output.dto
+
+import org.evomaster.core.EMConfig
+import org.evomaster.core.output.OutputFormat
+import org.evomaster.core.problem.rest.builder.RestActionBuilderV3
+import org.evomaster.core.problem.rest.schema.OpenApiAccess
+import org.evomaster.core.problem.rest.schema.RestSchema
+import org.evomaster.core.search.action.Action
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.hasItem
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.Paths
+
+class DtoWriterTest {
+
+    companion object {
+        val tmpTestSuitePath: Path = Paths.get(Files.createTempDirectory("dto-writer-test").toUri())
+        val outputFormat = OutputFormat.JAVA_JUNIT_4
+
+        val config = EMConfig().apply {
+            aiModelForResponseClassification = EMConfig.AIResponseClassifierModel.GLM
+            enableSchemaConstraintHandling = true
+            allowInvalidData = false
+            probRestDefault = 0.0
+            probRestExamples = 0.0
+        }
+        val options = RestActionBuilderV3.Options(config)
+        const val STRING = "String"
+        const val INTEGER = "Integer"
+        const val BOOLEAN = "Boolean"
+    }
+
+    @Test
+    fun javaIsOnlySupportedForDtos() {
+        val actionCluster = initRestSchema("/swagger/dto-writer/primitiveTypes.yaml")
+        val supportedOutputFormats = listOf(OutputFormat.JAVA_JUNIT_4, OutputFormat.JAVA_JUNIT_5)
+        val unsupportedOutputFormats = listOf(OutputFormat.KOTLIN_JUNIT_4, OutputFormat.KOTLIN_JUNIT_5, OutputFormat.JS_JEST,
+            OutputFormat.PYTHON_UNITTEST)
+
+        supportedOutputFormats.forEach { outputFormat ->
+            val dtoWriter = DtoWriter()
+            dtoWriter.write(tmpTestSuitePath, outputFormat, actionCluster.values.map { it.copy() })
+            assertTrue(dtoWriter.getCollectedDtos().isNotEmpty())
+        }
+
+        unsupportedOutputFormats.forEach { outputFormat ->
+            assertThrows(IllegalStateException::class.java, {
+                val dtoWriter = DtoWriter()
+                dtoWriter.write(tmpTestSuitePath, outputFormat, actionCluster.values.map { it.copy() })
+            })
+        }
+    }
+
+    @Test
+    fun emptyActionListReturnsNoDtos() {
+        val dtoWriter = DtoWriter()
+
+        dtoWriter.write(tmpTestSuitePath, outputFormat, emptyList())
+
+        assertTrue(dtoWriter.getCollectedDtos().isEmpty())
+    }
+
+    @Test
+    fun primitiveTypesAreCollectedAsDtoFields() {
+        val dtoWriter = DtoWriter()
+        val actionCluster = initRestSchema("/swagger/dto-writer/primitiveTypes.yaml")
+
+        dtoWriter.write(tmpTestSuitePath, outputFormat, actionCluster.values.map { it.copy() })
+
+        val collectedDtos = dtoWriter.getCollectedDtos()
+        assertEquals(collectedDtos.size, 1)
+        val postExampleDto = collectedDtos["POST__example"]
+        assertNotNull(postExampleDto)
+        val dtoFields = postExampleDto?.fields?:emptyList()
+        assertEquals(dtoFields.size, 12)
+        assertDtoFieldIn(dtoFields, "aString", STRING)
+        assertDtoFieldIn(dtoFields, "aRegex", STRING)
+        assertDtoFieldIn(dtoFields, "aBase64String", STRING)
+        assertDtoFieldIn(dtoFields, "aDate", STRING)
+        assertDtoFieldIn(dtoFields, "aTime", STRING)
+        assertDtoFieldIn(dtoFields, "aDateTime", STRING)
+        assertDtoFieldIn(dtoFields, "anInteger", INTEGER)
+        assertDtoFieldIn(dtoFields, "aLong", "Long")
+        assertDtoFieldIn(dtoFields, "aNumber", "Double")
+        assertDtoFieldIn(dtoFields, "aFloat", "Float")
+        assertDtoFieldIn(dtoFields, "aBoolean", BOOLEAN)
+        assertDtoFieldIn(dtoFields, "aNullableString", STRING)
+    }
+
+    @Test
+    fun childObjectInlineIsCollectedInDto() {
+        val dtoWriter = DtoWriter()
+        val actionCluster = initRestSchema("/swagger/dto-writer/childObjectInline.yaml")
+
+        dtoWriter.write(tmpTestSuitePath, outputFormat, actionCluster.values.map { it.copy() })
+
+        val collectedDtos = dtoWriter.getCollectedDtos()
+        assertEquals(collectedDtos.size, 2)
+        val postExampleDto = collectedDtos["POST__example"]
+        assertNotNull(postExampleDto)
+        val dtoFields = postExampleDto?.fields?:emptyList()
+        assertEquals(dtoFields.size, 2)
+        assertDtoFieldIn(dtoFields, "aString", STRING)
+        assertDtoFieldIn(dtoFields, "anObject", "Anobject")
+
+        val childObjectDto = collectedDtos["Anobject"]
+        assertNotNull(childObjectDto)
+        val childObjectDtoFields = childObjectDto?.fields?:emptyList()
+        assertEquals(childObjectDtoFields.size, 2)
+        assertDtoFieldIn(childObjectDtoFields, "name", STRING)
+        assertDtoFieldIn(childObjectDtoFields, "age", INTEGER)
+    }
+
+    @Test
+    fun whenUsingComponentsDtoNameIsSchemaName() {
+        val dtoWriter = DtoWriter()
+        val actionCluster = initRestSchema("/swagger/dto-writer/simpleComponents.yaml")
+
+        dtoWriter.write(tmpTestSuitePath, outputFormat, actionCluster.values.map { it.copy() })
+
+        val collectedDtos = dtoWriter.getCollectedDtos()
+        assertEquals(collectedDtos.size, 2)
+        val firstSchema = collectedDtos["FirstSchema"]
+        assertNotNull(firstSchema)
+        val dtoFields = firstSchema?.fields?:emptyList()
+        assertEquals(dtoFields.size, 1)
+        assertDtoFieldIn(dtoFields, "message", STRING)
+
+        val secondSchema = collectedDtos["SecondSchema"]
+        assertNotNull(secondSchema)
+        val childObjectDtoFields = secondSchema?.fields?:emptyList()
+        assertEquals(childObjectDtoFields.size, 1)
+        assertDtoFieldIn(childObjectDtoFields, "active", BOOLEAN)
+    }
+
+    @Test
+    fun childObjectComponentIsCollectedInDto() {
+        val dtoWriter = DtoWriter()
+        val actionCluster = initRestSchema("/swagger/dto-writer/childObjectComponent.yaml")
+
+        dtoWriter.write(tmpTestSuitePath, outputFormat, actionCluster.values.map { it.copy() })
+
+        val collectedDtos = dtoWriter.getCollectedDtos()
+        assertEquals(collectedDtos.size, 2)
+        val postExampleDto = collectedDtos["ParentSchema"]
+        assertNotNull(postExampleDto)
+        val dtoFields = postExampleDto?.fields?:emptyList()
+        assertEquals(dtoFields.size, 2)
+        assertDtoFieldIn(dtoFields, "label", STRING)
+        assertDtoFieldIn(dtoFields, "child", "ChildSchema")
+
+        val childObjectDto = collectedDtos["ChildSchema"]
+        assertNotNull(childObjectDto)
+        val childObjectDtoFields = childObjectDto?.fields?:emptyList()
+        assertEquals(childObjectDtoFields.size, 2)
+        assertDtoFieldIn(childObjectDtoFields, "name", STRING)
+        assertDtoFieldIn(childObjectDtoFields, "age", INTEGER)
+    }
+
+    private fun initRestSchema(openApiLocation: String) : Map<String, Action> {
+        val restSchema = RestSchema(OpenApiAccess.getOpenAPIFromResource(openApiLocation))
+        val actionCluster = mutableMapOf<String, Action>()
+        RestActionBuilderV3.addActionsFromSwagger(restSchema, actionCluster, options = options)
+        return actionCluster
+    }
+
+    private fun assertDtoFieldIn(dtoFields: List<DtoField>, targetName: String, targetType: String) {
+        assertThat(dtoFields, hasItem(DtoField(targetName, targetType)))
+    }
+}

--- a/core/src/test/resources/swagger/dto-writer/childObjectComponent.yaml
+++ b/core/src/test/resources/swagger/dto-writer/childObjectComponent.yaml
@@ -1,0 +1,45 @@
+openapi: 3.0.3
+info:
+  title: Nested Schema Example API
+  version: 1.0.0
+
+paths:
+  /parent:
+    post:
+      summary: Uses ParentSchema, which references ChildSchema
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ParentSchema'
+      responses:
+        '200':
+          description: OK
+
+components:
+  schemas:
+    ParentSchema:
+      type: object
+      properties:
+        label:
+          type: string
+          example: "Parent label"
+        child:
+          $ref: '#/components/schemas/ChildSchema'
+      required:
+        - label
+        - child
+
+    ChildSchema:
+      type: object
+      properties:
+        name:
+          type: string
+          example: "Nested child name"
+        age:
+          type: integer
+          example: 10
+      required:
+        - name
+        - age

--- a/core/src/test/resources/swagger/dto-writer/childObjectInline.yaml
+++ b/core/src/test/resources/swagger/dto-writer/childObjectInline.yaml
@@ -1,0 +1,38 @@
+openapi: 3.0.0
+info:
+  title: Child Object DTO API
+  version: 1.0.0
+servers:
+  - url: http://localhost:5000
+paths:
+  /example:
+    post:
+      summary: Example with a simple nested object
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                aString:
+                  type: string
+                  example: "some value"
+                anObject:
+                  type: object
+                  properties:
+                    name:
+                      type: string
+                      example: "Alice"
+                    age:
+                      type: integer
+                      example: 30
+                  required:
+                    - name
+                    - age
+              required:
+                - aString
+                - anObject
+      responses:
+        '200':
+          description: OK

--- a/core/src/test/resources/swagger/dto-writer/primitiveTypes.yaml
+++ b/core/src/test/resources/swagger/dto-writer/primitiveTypes.yaml
@@ -1,0 +1,76 @@
+openapi: 3.0.0
+info:
+  title: Primitive Types DTO API
+  version: 1.0.0
+servers:
+  - url: http://localhost:5000
+paths:
+  /example:
+    post:
+      summary: Example with all primitive and format types (no array/object)
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                aString:
+                  type: string
+                  example: "hello"
+                aRegex:
+                  type: string
+                  pattern: "^[a-zA-Z0-9]+$"
+                  example: "abc123"
+                aBase64String:
+                  type: string
+                  format: byte
+                  example: "SGVsbG8gd29ybGQ="  # "Hello world" base64
+                aDate:
+                  type: string
+                  format: date
+                  example: "2025-08-03"
+                aTime:
+                  type: string
+                  format: time
+                  example: "14:30:00"
+                aDateTime:
+                  type: string
+                  format: date-time
+                  example: "2025-08-03T14:30:00Z"
+                anInteger:
+                  type: integer
+                  example: 42
+                aLong:
+                  type: integer
+                  format: int64
+                  example: 9223372036854775807
+                aNumber:
+                  type: number
+                  example: 3.1415
+                aFloat:
+                  type: number
+                  format: float
+                  example: 2.718
+                aBoolean:
+                  type: boolean
+                  example: true
+                aNullableString:
+                  type: string
+                  nullable: true
+                  example: null
+              required:
+                - aString
+                - aRegex
+                - aBase64String
+                - aDate
+                - aTime
+                - aDateTime
+                - anInteger
+                - aLong
+                - aNumber
+                - aFloat
+                - aBoolean
+      responses:
+        '200':
+          description: OK

--- a/core/src/test/resources/swagger/dto-writer/simpleComponents.yaml
+++ b/core/src/test/resources/swagger/dto-writer/simpleComponents.yaml
@@ -1,0 +1,51 @@
+openapi: 3.0.3
+info:
+  title: Two Simple Schemas Example API
+  version: 1.0.0
+
+paths:
+  /first:
+    post:
+      summary: Uses FirstSchema
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/FirstSchema'
+      responses:
+        '200':
+          description: OK
+
+  /second:
+    post:
+      summary: Uses SecondSchema
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SecondSchema'
+      responses:
+        '200':
+          description: OK
+
+components:
+  schemas:
+    FirstSchema:
+      type: object
+      properties:
+        message:
+          type: string
+          example: "Hello from FirstSchema"
+      required:
+        - message
+
+    SecondSchema:
+      type: object
+      properties:
+        active:
+          type: boolean
+          example: true
+      required:
+        - status


### PR DESCRIPTION
Adding unit tests for DTO generation. The goal is to assert only that given a schema, the expected DTOs are generated in the EM abstraction. Valid code generation of DTOs will be later tested using e2e tests.
Included tests are:
- primitive types in an inline schema
- child object in an inline schema
- simple different objects in the components section
- child object in the components section