### PR TITLE
parse Cypher parameters into their own operand

### DIFF
--- a/client-java/controller/src/main/java/org/evomaster/client/java/controller/neo4j/conditions/ParameterOperand.java
+++ b/client-java/controller/src/main/java/org/evomaster/client/java/controller/neo4j/conditions/ParameterOperand.java
@@ -1,0 +1,43 @@
+package org.evomaster.client.java.controller.neo4j.conditions;
+
+import java.util.Objects;
+
+/**
+ * A query parameter reference such as {@code $title}, whose value is not written in the query but
+ * supplied at execution time. Carries the parameter name without the leading {@code $}, so the value
+ * can later be looked up in the parameter map captured alongside the query.
+ * <p>
+ * Told apart from {@link RawOperand} on purpose. Both are unresolved when the query is parsed, but a
+ * parameter has a value that can be recovered, whereas a {@code RawOperand} is an expression the model
+ * chose not to decompose at all.
+ */
+public final class ParameterOperand implements Operand {
+
+    private final String name;
+
+    public ParameterOperand(String name) {
+        this.name = Objects.requireNonNull(name, "name must not be null");
+    }
+
+    /** The parameter name without the leading {@code $}: {@code title} for {@code $title}. */
+    public String getName() {
+        return name;
+    }
+
+    @Override
+    public String toString() {
+        return "$" + name;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        return Objects.equals(name, ((ParameterOperand) o).name);
+    }
+
+    @Override
+    public int hashCode() {
+        return name.hashCode();
+    }
+}

--- a/client-java/controller/src/main/java/org/evomaster/client/java/controller/neo4j/parser/cypher25/Cypher25MatchVisitor.java
+++ b/client-java/controller/src/main/java/org/evomaster/client/java/controller/neo4j/parser/cypher25/Cypher25MatchVisitor.java
@@ -486,7 +486,8 @@ class Cypher25MatchVisitor extends Cypher25ParserBaseVisitor<Void> {
     /**
      * Classifies one side of a comparison: a property reference {@code variable.key} as a
      * {@link PropertyOperand}, a list {@code [..]} as a {@link ListOperand} of element operands,
-     * an operand that is exactly a literal as a {@link LiteralOperand}, an arithmetic expression
+     * an operand that is exactly a literal as a {@link LiteralOperand}, a parameter reference
+     * {@code $name} as a {@link ParameterOperand}, an arithmetic expression
      * ({@code + - * / % ^}, unary minus) as an {@link ArithmeticOperand} (folded to a literal when
      * every leaf is a numeric literal), and anything else (a function call) as a {@link RawOperand}.
      */
@@ -494,6 +495,10 @@ class Cypher25MatchVisitor extends Cypher25ParserBaseVisitor<Void> {
         PropertyOperand property = propertyReference(expression);
         if (property != null) {
             return property;
+        }
+        Cypher25Parser.ParameterContext parameter = soleParameter(expression);
+        if (parameter != null) {
+            return new ParameterOperand(parameterName(parameter));
         }
         Cypher25Parser.ListLiteralContext list = soleList(expression);
         if (list != null) {
@@ -648,7 +653,26 @@ class Cypher25MatchVisitor extends Cypher25ParserBaseVisitor<Void> {
         if (tokenType == Cypher25Parser.DIVIDE) return ArithmeticOperator.DIVIDE;
         if (tokenType == Cypher25Parser.PERCENT) return ArithmeticOperator.MODULO;
         if (tokenType == Cypher25Parser.POW) return ArithmeticOperator.POWER;
-        return null;                                              // DOUBLEBAR (||) etc.: not numeric arithmetic
+        return null;
+    }
+
+    /** The parameter an operand reduces to when it is nothing but {@code $name}, else null. */
+    private Cypher25Parser.ParameterContext soleParameter(ParseTree expression) {
+        ParseTree node = descendSingleChild(expression);
+        return node instanceof Cypher25Parser.ParameterContext
+                ? (Cypher25Parser.ParameterContext) node
+                : null;
+    }
+
+    /**
+     * The name of a parameter, without the leading {@code $}. A parameter can also be positional
+     * ({@code $0}), in which case the name is the digits.
+     */
+    private String parameterName(Cypher25Parser.ParameterContext ctx) {
+        Cypher25Parser.ParameterNameContext parameterName = ctx.parameterName();
+        return parameterName.symbolicNameString() != null
+                ? name(parameterName.symbolicNameString())
+                : parameterName.getText();
     }
 
     /** The list literal an operand reduces to when it is nothing but {@code [..]}, else null. */
@@ -730,7 +754,11 @@ class Cypher25MatchVisitor extends Cypher25ParserBaseVisitor<Void> {
         Map<String, Operand> result = new LinkedHashMap<>();
         Cypher25Parser.MapContext map = ctx.map();
         if (map == null) {
-            return result; // parameterised properties ($props) carry no literal values
+            // The whole property map comes from a parameter ($props), so the keys are unknown until
+            // the query runs. Recorded as a RawCondition rather than returning nothing, so the
+            // constraint still weighs on the score instead of the element looking unconstrained.
+            conditionSink.add(new RawCondition(ctx.getText()));
+            return result;
         }
         List<Cypher25Parser.PropertyKeyNameContext> keys = map.propertyKeyName();
         List<Cypher25Parser.ExpressionContext> values = map.expression();

--- a/client-java/controller/src/test/java/org/evomaster/client/java/controller/neo4j/parser/Cypher25AntlrParserTest.java
+++ b/client-java/controller/src/test/java/org/evomaster/client/java/controller/neo4j/parser/Cypher25AntlrParserTest.java
@@ -7,6 +7,10 @@ import org.evomaster.client.java.controller.neo4j.operations.QuantifiedPathPatte
 import org.evomaster.client.java.controller.neo4j.parser.cypher25.Cypher25AntlrParser;
 import org.junit.jupiter.api.Test;
 
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
 import static org.junit.jupiter.api.Assertions.*;
 
 /**
@@ -206,10 +210,102 @@ class Cypher25AntlrParserTest {
     }
 
     @Test
-    void testPropertyParameterValueKeptAsRawOperand() {
+    void testPropertyParameterValueIsAParameterOperand() {
         PropertyCondition prop = (PropertyCondition) parse("MATCH (p {age: $minAge}) RETURN p")
                 .getConditions().stream().filter(PropertyCondition.class::isInstance).findFirst().orElseThrow(AssertionError::new);
-        assertInstanceOf(RawOperand.class, prop.getValue());
+        assertEquals(new ParameterOperand("minAge"), prop.getValue());
+    }
+
+    @Test
+    void testComparisonParameterValueIsAParameterOperand() {
+        ComparisonCondition cc = comparison(parse("MATCH (p:Person) WHERE p.name = $name RETURN p"));
+        assertEquals(new PropertyOperand("p", "name"), cc.getLeft());
+        assertEquals(new ParameterOperand("name"), cc.getRight());
+    }
+
+    @Test
+    void testParameterOperandKeepsTheNameWithoutTheDollar() {
+        ComparisonCondition cc = comparison(parse("MATCH (p:Person) WHERE p.age > $minAge RETURN p"));
+        ParameterOperand param = (ParameterOperand) cc.getRight();
+        assertEquals("minAge", param.getName());
+        assertEquals("$minAge", param.toString());
+    }
+
+    @Test
+    void testEscapedParameterNameIsUnquoted() {
+        ComparisonCondition cc = comparison(parse("MATCH (p:Person) WHERE p.age > $`min age` RETURN p"));
+        assertEquals(new ParameterOperand("min age"), cc.getRight());
+    }
+
+    @Test
+    void testPositionalParameterKeepsItsDigits() {
+        ComparisonCondition cc = comparison(parse("MATCH (p:Person) WHERE p.age > $0 RETURN p"));
+        assertEquals(new ParameterOperand("0"), cc.getRight());
+    }
+
+    @Test
+    void testParameterOnTheLeftOfAComparison() {
+        ComparisonCondition cc = comparison(parse("MATCH (p:Person) WHERE $name = p.name RETURN p"));
+        assertEquals(new ParameterOperand("name"), cc.getLeft());
+        assertEquals(new PropertyOperand("p", "name"), cc.getRight());
+    }
+
+    @Test
+    void testTwoParametersInTheSameQueryStayDistinct() {
+        MatchOperation op = parse("MATCH (p:Person) WHERE p.age > $min AND p.age < $max RETURN p");
+        List<Operand> params = op.getConditions().stream()
+                .filter(AndCondition.class::isInstance)
+                .flatMap(c -> ((AndCondition) c).getConditions().stream())
+                .filter(ComparisonCondition.class::isInstance)
+                .map(c -> ((ComparisonCondition) c).getRight())
+                .collect(Collectors.toList());
+        assertEquals(Arrays.asList(new ParameterOperand("min"), new ParameterOperand("max")), params);
+    }
+
+    @Test
+    void testPropertyOfAParameterIsNotAParameterOperand() {
+        // $user.name is a property access on a parameter, not a parameter reference: neither half can
+        // be resolved on its own, so the whole thing stays raw.
+        ComparisonCondition cc = comparison(parse("MATCH (p:Person) WHERE p.name = $user.name RETURN p"));
+        assertInstanceOf(RawOperand.class, cc.getRight());
+        assertEquals("$user.name", ((RawOperand) cc.getRight()).getText());
+    }
+
+    @Test
+    void testParameterInsideArithmeticStaysAParameterOperand() {
+        // The arithmetic tree is still built; only the parameter leaf is left unresolved.
+        ComparisonCondition cc = comparison(parse("MATCH (p:Person) WHERE p.age > $minAge + 1 RETURN p"));
+        ArithmeticOperand sum = (ArithmeticOperand) cc.getRight();
+        assertEquals(new ParameterOperand("minAge"), sum.getLeft());
+        assertEquals(new LiteralOperand(1L), sum.getRight());
+    }
+
+    @Test
+    void testParameterInsideListStaysAParameterOperand() {
+        ComparisonCondition cc = comparison(parse("MATCH (p:Person) WHERE p.name IN [$a, \"bob\"] RETURN p"));
+        ListOperand list = (ListOperand) cc.getRight();
+        assertEquals(new ParameterOperand("a"), list.getElements().get(0));
+        assertEquals(new LiteralOperand("bob"), list.getElements().get(1));
+    }
+
+    @Test
+    void testNodeParameterisedPropertyMapIsKeptAsRawCondition() {
+        // MATCH (m:Movie $props): the keys are only known at execution time, so the constraint is
+        // recorded whole instead of being dropped, which would leave the node looking unconstrained.
+        MatchOperation op = parse("MATCH (m:Movie $props) RETURN m");
+        assertEquals(0, countOf(op, PropertyCondition.class));
+        assertEquals(1, countOf(op, RawCondition.class));
+        assertEquals("$props", op.getConditions().stream()
+                .filter(RawCondition.class::isInstance)
+                .map(c -> ((RawCondition) c).getExpression())
+                .findFirst().orElseThrow(AssertionError::new));
+    }
+
+    @Test
+    void testRelationshipParameterisedPropertyMapIsKeptAsRawCondition() {
+        MatchOperation op = parse("MATCH (a)-[r:KNOWS $props]->(b) RETURN r");
+        assertEquals(0, countOf(op, PropertyCondition.class));
+        assertEquals(1, countOf(op, RawCondition.class));
     }
 
     @Test


### PR DESCRIPTION
Independent of #1647: this only touches the parser, which is already in master.

- New `ParameterOperand`, a `$name` reference, keeping the parameter name so its value can be looked up once the driver-side wiring lands. Until now a parameter was indistinguishable from any other expression the model does not decompose, both were a `RawOperand`
- `MATCH (m:Movie $props)`, where the whole property map comes from a parameter, no longer drops the properties silently: the constraint is kept as a `RawCondition` instead of the element looking unconstrained
- No behavior change in the heuristics: an operand type they do not know is already left unresolved, exactly as `RawOperand` is today
- Resolving a parameter against the values captured at execution time is a follow-up, it needs the Neo4j handler
- 11 tests