### PR TITLE
We added test memorization upon minimization to avoid losing test coverage

### DIFF
--- a/core/src/main/kotlin/org/evomaster/core/search/service/Minimizer.kt
+++ b/core/src/main/kotlin/org/evomaster/core/search/service/Minimizer.kt
@@ -196,6 +196,11 @@ class Minimizer<T: Individual> : TimeBoxedPhase {
 
         val beforeCovered = archive.coveredTargets()
 
+        //fallback in case recomputation below does not reproduce a currently covered target
+        val originalByTarget = archive.getSnapshotOfBestIndividuals()
+            .filterKeys { beforeCovered.contains(it) }
+            .mapValues { (_, individuals) -> individuals[0] }
+
         val currentEvaluated = archive.getCopyOfUniqueCoveringEvaluatedIndividuals()
 
         LoggingUtil.getInfoLogger().info("Recomputing full coverage for ${currentEvaluated.size} tests")
@@ -228,24 +233,36 @@ class Minimizer<T: Individual> : TimeBoxedPhase {
 
         population.forEach{archive.addIfNeeded(it)}
 
+        //re-running a test can be non-deterministic (eg background threads, shared mutable state),
+        //so restore the original test for any target that recomputation failed to reproduce
         val afterCovered = archive.coveredTargets()
-        val diff = beforeCovered.size-afterCovered.size
+        val notReproduced = beforeCovered.filter { !afterCovered.contains(it) }
 
-        if(diff > config.minimizeThresholdForLoss *  beforeCovered.size){
-            //could happen if background threads, for example, as well as constructors of singletons
-            LoggingUtil.getInfoLogger().warn("Recomputing coverage did lose many targets," +
-                    " more than the threshold ${config.minimizeThresholdForLoss*100}%:" +
-                    " from ${beforeCovered.size} to ${afterCovered.size}" +
-                    ", i.e., lost $diff")
+        if(notReproduced.isNotEmpty()){
+            LoggingUtil.getInfoLogger().warn("Recomputing coverage did not reproduce ${notReproduced.size} targets" +
+                    " previously covered (likely due to non-deterministic behavior in the SUT)." +
+                    " Restoring the original tests for them so that no achieved coverage is lost.")
 
             if(config.minimizeShowLostTargets){
-                LoggingUtil.getInfoLogger().warn("Missing targets:");
-                for(target in beforeCovered){
-                    if(! afterCovered.contains(target)){
-                        LoggingUtil.getInfoLogger().warn(idMapper.getDescriptiveId(target));
-                    }
+                LoggingUtil.getInfoLogger().warn("Targets not reproduced on recomputation:");
+                for(target in notReproduced){
+                    LoggingUtil.getInfoLogger().warn(idMapper.getDescriptiveId(target));
                 }
             }
+
+            notReproduced.forEach { target ->
+                originalByTarget[target]?.let { archive.addIfNeeded(it) }
+            }
+        }
+
+        val stillMissing = beforeCovered.size - archive.coveredTargets().size
+
+        if(stillMissing > config.minimizeThresholdForLoss *  beforeCovered.size){
+            //could happen if the original test itself is no longer accepted, eg a death sentence
+            LoggingUtil.getInfoLogger().warn("Even after restoring original tests, still lost many targets," +
+                    " more than the threshold ${config.minimizeThresholdForLoss*100}%:" +
+                    " from ${beforeCovered.size} to ${archive.coveredTargets().size}" +
+                    ", i.e., lost $stillMissing")
 
             assert(false)//shouldn't really happen in the E2E...
         }

--- a/core/src/test/kotlin/org/evomaster/core/search/service/MinimizerTest.kt
+++ b/core/src/test/kotlin/org/evomaster/core/search/service/MinimizerTest.kt
@@ -1,0 +1,101 @@
+package org.evomaster.core.search.service
+
+import com.google.inject.Injector
+import com.google.inject.Key
+import com.google.inject.TypeLiteral
+import com.netflix.governator.guice.LifecycleInjector
+import org.evomaster.core.BaseModule
+import org.evomaster.core.EMConfig
+import org.evomaster.core.TestUtils
+import org.evomaster.core.search.service.minimizer.MultiActionAction
+import org.evomaster.core.search.service.minimizer.MultiActionFitness
+import org.evomaster.core.search.service.minimizer.MultiActionIndividual
+import org.evomaster.core.search.service.minimizer.MultiActionModule
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class MinimizerTest {
+
+    private lateinit var archive: Archive<MultiActionIndividual>
+    private lateinit var fitness: MultiActionFitness
+    private lateinit var config: EMConfig
+    private lateinit var minimizer: Minimizer<MultiActionIndividual>
+
+    @BeforeEach
+    fun init() {
+
+        val injector: Injector = LifecycleInjector.builder()
+            .withModules(MultiActionModule(), BaseModule(arrayOf("--blackBox", "false")))
+            .build().createInjector()
+
+        archive = injector.getInstance(Key.get(
+            object : TypeLiteral<Archive<MultiActionIndividual>>() {}))
+        fitness = injector.getInstance(MultiActionFitness::class.java)
+        config = injector.getInstance(EMConfig::class.java)
+        minimizer = injector.getInstance(Key.get(
+            object : TypeLiteral<Minimizer<MultiActionIndividual>>() {}))
+
+        config.seed = 42
+        config.stoppingCriterion = EMConfig.StoppingCriterion.ACTION_EVALUATIONS
+    }
+
+    @Test
+    fun testCoverageIsNotLostWhenMinimizingMultiActionTarget() {
+
+        val ind = MultiActionIndividual(listOf(
+            MultiActionAction(0),
+            MultiActionAction(1),
+            MultiActionAction(2)
+        ))
+        TestUtils.doInitializeIndividualForTesting(ind)
+
+        fitness.targetRequirements = mapOf(
+            100 to setOf(0),
+            101 to setOf(2),
+            200 to setOf(0, 1)  //only covered when actions 0 AND 1 are both present
+        )
+
+        val evaluated = fitness.computeWholeAchievedCoverageForPostProcessing(ind)!!
+        val added = archive.addIfNeeded(evaluated)
+        assertTrue(added)
+
+        assertTrue(archive.isCovered(100))
+        assertTrue(archive.isCovered(101))
+        assertTrue(archive.isCovered(200))
+
+        minimizer.applyPhase()
+
+        assertTrue(archive.isCovered(100), "Lost target 100, which only needs 1 action")
+        assertTrue(archive.isCovered(101), "Lost target 101, which only needs 1 action")
+        assertTrue(archive.isCovered(200), "Lost target 200, which needs actions 0 and 1 together")
+    }
+
+    @Test
+    fun testCoverageIsNotLostDueToNonDeterministicReEvaluation() {
+
+        val ind = MultiActionIndividual(listOf(
+            MultiActionAction(0),
+            MultiActionAction(1)
+        ))
+        TestUtils.doInitializeIndividualForTesting(ind)
+
+        fitness.targetRequirements = mapOf(
+            100 to setOf(0),
+            300 to setOf(0)
+        )
+        fitness.flakyTarget = 300
+
+        val evaluated = fitness.computeWholeAchievedCoverageForPostProcessing(ind)!!
+        val added = archive.addIfNeeded(evaluated)
+        assertTrue(added)
+
+        assertTrue(archive.isCovered(100))
+        assertTrue(archive.isCovered(300))
+
+        minimizer.applyPhase()
+
+        assertTrue(archive.isCovered(100), "Lost target 100, which is deterministic")
+        assertTrue(archive.isCovered(300), "Lost target 300 due to non-deterministic re-evaluation during minimization")
+    }
+}

--- a/core/src/test/kotlin/org/evomaster/core/search/service/minimizer/MultiActionAction.kt
+++ b/core/src/test/kotlin/org/evomaster/core/search/service/minimizer/MultiActionAction.kt
@@ -1,0 +1,20 @@
+package org.evomaster.core.search.service.minimizer
+
+import org.evomaster.core.search.StructuralElement
+import org.evomaster.core.search.action.MainAction
+import org.evomaster.core.search.gene.Gene
+
+class MultiActionAction(val id: Int) : MainAction(isCleanUp = false, children = listOf()) {
+
+    override fun getName(): String {
+        return "MultiAction_$id"
+    }
+
+    override fun seeTopGenes(): List<Gene> {
+        return listOf()
+    }
+
+    override fun copyContent(): StructuralElement {
+        return MultiActionAction(id)
+    }
+}

--- a/core/src/test/kotlin/org/evomaster/core/search/service/minimizer/MultiActionFitness.kt
+++ b/core/src/test/kotlin/org/evomaster/core/search/service/minimizer/MultiActionFitness.kt
@@ -1,0 +1,52 @@
+package org.evomaster.core.search.service.minimizer
+
+import org.evomaster.core.search.EvaluatedIndividual
+import org.evomaster.core.search.FitnessValue
+import org.evomaster.core.search.service.FitnessFunction
+import org.evomaster.core.search.tracer.Traceable
+
+class MultiActionFitness : FitnessFunction<MultiActionIndividual>() {
+
+    //target id -> set of action ids that must ALL be present for the target to be covered
+    var targetRequirements: Map<Int, Set<Int>> = emptyMap()
+
+    //if set, this target is reported as covered only the first time a given individual (by its
+    //set of action ids) is evaluated, simulating a flaky/non-deterministic SUT
+    var flakyTarget: Int? = null
+    private val evaluationCountByActionSet = mutableMapOf<Set<Int>, Int>()
+
+    override fun doCalculateCoverage(
+        individual: MultiActionIndividual,
+        targets: Set<Int>,
+        allTargets: Boolean,
+        fullyCovered: Boolean,
+        descriptiveIds: Boolean,
+    ): EvaluatedIndividual<MultiActionIndividual>? {
+
+        val fv = FitnessValue(individual.size().toDouble())
+
+        val presentIds = individual.seeMainExecutableActions().map { it.id }.toSet()
+
+        val evaluationCount = evaluationCountByActionSet.getOrDefault(presentIds, 0)
+        evaluationCountByActionSet[presentIds] = evaluationCount + 1
+
+        val toEvaluate = if (allTargets) targetRequirements.keys else targetsToEvaluate(targets, individual)
+
+        toEvaluate.forEach { t ->
+            val required = targetRequirements[t] ?: return@forEach
+            val structurallyCovered = presentIds.containsAll(required)
+            val covered = structurallyCovered && (t != flakyTarget || evaluationCount == 0)
+            fv.updateTarget(t, if (covered) 1.0 else 0.0)
+        }
+
+        return EvaluatedIndividual(
+            fv, individual.copy() as MultiActionIndividual,
+            listOf(), config = config, trackOperator = individual.trackOperator,
+            index = if (config.trackingEnabled()) time.evaluatedIndividuals else Traceable.DEFAULT_INDEX
+        )
+    }
+
+    override fun targetsToEvaluate(targets: Set<Int>, individual: MultiActionIndividual): Set<Int> {
+        return if (targets.isEmpty()) targetRequirements.keys else targets
+    }
+}

--- a/core/src/test/kotlin/org/evomaster/core/search/service/minimizer/MultiActionIndividual.kt
+++ b/core/src/test/kotlin/org/evomaster/core/search/service/minimizer/MultiActionIndividual.kt
@@ -1,0 +1,44 @@
+package org.evomaster.core.search.service.minimizer
+
+import org.evomaster.core.search.Individual
+import org.evomaster.core.search.action.Action
+import org.evomaster.core.search.action.ActionFilter
+import org.evomaster.core.search.gene.Gene
+import org.evomaster.core.search.service.Randomness
+
+//unlike OneMaxIndividual/ConstantIndividual, size() is not hardcoded to 1, as Minimizer needs
+//individuals with a variable number of main-executable actions
+class MultiActionIndividual(actions: List<MultiActionAction>) : Individual(children = actions.toMutableList()) {
+
+    override fun copyContent(): Individual {
+        return MultiActionIndividual(children.map { it.copy() as MultiActionAction })
+    }
+
+    override fun seeActions(filter: ActionFilter): List<Action> {
+        return when (filter) {
+            ActionFilter.ALL, ActionFilter.NO_INIT, ActionFilter.MAIN_EXECUTABLE -> seeAllActions()
+            else -> listOf()
+        }
+    }
+
+    override fun seeMainExecutableActions(): List<MultiActionAction> {
+        @Suppress("UNCHECKED_CAST")
+        return super.seeMainExecutableActions() as List<MultiActionAction>
+    }
+
+    override fun seeTopGenes(filter: ActionFilter): List<Gene> {
+        return listOf()
+    }
+
+    override fun size(): Int {
+        return children.size
+    }
+
+    override fun isValidInitializationActions(errors: MutableList<String>?): Boolean {
+        return true
+    }
+
+    override fun repairInitializationActions(randomness: Randomness) {
+        //no-op
+    }
+}

--- a/core/src/test/kotlin/org/evomaster/core/search/service/minimizer/MultiActionModule.kt
+++ b/core/src/test/kotlin/org/evomaster/core/search/service/minimizer/MultiActionModule.kt
@@ -1,0 +1,65 @@
+package org.evomaster.core.search.service.minimizer
+
+import com.google.inject.AbstractModule
+import com.google.inject.TypeLiteral
+import org.evomaster.core.output.service.NoTestCaseWriter
+import org.evomaster.core.output.service.TestCaseWriter
+import org.evomaster.core.search.service.*
+import org.evomaster.core.search.service.mutator.EmptyStructureMutator
+import org.evomaster.core.search.service.mutator.Mutator
+import org.evomaster.core.search.service.mutator.StandardMutator
+import org.evomaster.core.search.service.mutator.StructureMutator
+import org.evomaster.core.search.tracer.ArchiveMutationTrackService
+import org.evomaster.core.search.tracer.TrackService
+
+class MultiActionModule : AbstractModule() {
+
+    override fun configure() {
+        bind(object : TypeLiteral<Sampler<*>>() {})
+            .to(MultiActionSampler::class.java)
+            .asEagerSingleton()
+
+        bind(object : TypeLiteral<Sampler<MultiActionIndividual>>() {})
+            .to(MultiActionSampler::class.java)
+            .asEagerSingleton()
+
+        bind(MultiActionSampler::class.java)
+            .asEagerSingleton()
+
+        bind(object : TypeLiteral<FitnessFunction<MultiActionIndividual>>() {})
+            .to(MultiActionFitness::class.java)
+            .asEagerSingleton()
+
+        bind(MultiActionFitness::class.java)
+            .asEagerSingleton()
+
+        bind(object : TypeLiteral<Mutator<MultiActionIndividual>>() {})
+            .to(object : TypeLiteral<StandardMutator<MultiActionIndividual>>() {})
+            .asEagerSingleton()
+
+        bind(object : TypeLiteral<Archive<MultiActionIndividual>>() {})
+            .asEagerSingleton()
+
+        bind(object : TypeLiteral<Archive<*>>() {})
+            .to(object : TypeLiteral<Archive<MultiActionIndividual>>() {})
+            .asEagerSingleton()
+
+        bind(object : TypeLiteral<Minimizer<MultiActionIndividual>>() {})
+            .asEagerSingleton()
+
+        bind(StructureMutator::class.java)
+            .to(EmptyStructureMutator::class.java)
+            .asEagerSingleton()
+
+        bind(TrackService::class.java)
+            .to(ArchiveMutationTrackService::class.java)
+            .asEagerSingleton()
+
+        bind(ArchiveMutationTrackService::class.java)
+            .asEagerSingleton()
+
+        bind(TestCaseWriter::class.java)
+            .to(NoTestCaseWriter::class.java)
+            .asEagerSingleton()
+    }
+}

--- a/core/src/test/kotlin/org/evomaster/core/search/service/minimizer/MultiActionSampler.kt
+++ b/core/src/test/kotlin/org/evomaster/core/search/service/minimizer/MultiActionSampler.kt
@@ -1,0 +1,18 @@
+package org.evomaster.core.search.service.minimizer
+
+import org.evomaster.client.java.controller.api.dto.SutInfoDto
+import org.evomaster.core.search.service.Sampler
+
+class MultiActionSampler : Sampler<MultiActionIndividual>() {
+
+    override fun sampleAtRandom(): MultiActionIndividual {
+        val sampled = MultiActionIndividual(listOf(MultiActionAction(0)))
+        sampled.doInitialize(randomness)
+        sampled.doGlobalInitialize(searchGlobalState)
+        return sampled
+    }
+
+    override fun initSeededTests(infoDto: SutInfoDto?) {
+        //no-op
+    }
+}


### PR DESCRIPTION
- Minimizer re-runs each test before minimizing to gather complete information; if the SUT is non-deterministic, that second run might not reproduce a previously covered target—and previously, that failure went unnoticed.

- The test as a reproduction case: it simulates this non-determinism in a controlled manner (a target reported as covered only during the initial test evaluation) and verifies that it remains covered after minimization. 

Approach of the fix:

- Previously: if, during test re-evaluation for minimization, a previously covered target failed to reproduce, the code merely logged a warning (and included an `assert(false)` that does nothing in production)—resulting in a silent loss of coverage with no attempt to recover it.
- Now: before rebuilding the file, a reference to the original test for each covered target is saved. If re-evaluation fails to reproduce a target, that original test is reinserted instead of just issuing a warning—ensuring that achieved coverage is never lost.


What the tests does:

1.  Sets up a mock test with 2 actions (lines 77-81)—a `MultiActionIndividual` with action IDs 0 and 1. This isn't real HTTP; they are in-memory tokens.

2. Defines 2 coverage targets (lines 83-86):

Target 100: covered by action 0, and always reports correctly (stable).
Target 300: structurally also covered by action 0—but...
3. `fitness.flakyTarget = 300` (line 87)—instructs the `MultiActionFitness` fixture: "the first time you evaluate this specific test, report target 300 as covered. For any subsequent evaluation of the same test, report it as NOT covered," even though the actual condition (having action 0) remains met. This simulates—in a controlled, 100% reproducible way—an SUT that yields a different result if you run the same test twice, without requiring real threads or real timing.

4. Evaluates the test once (line 89) and adds it to the coverage archive (line 90)—this is the "first run," as if it were part of the normal search. Confirms that both targets are covered (lines 93-94).

5. Calls `minimizer.applyPhase()` (line 96)—the actual minimization phase, the production code without any mocks. Internally, the `Minimizer` re-evaluates that same test to gather complete information (`recomputeArchiveWithFullCoverageInfo()`). That marks the second evaluation of the same test—and since the `flakyTarget` status applies only the first time, target 300 now reports as "not covered."

6. The final assertions (lines 98-99): target 100 (stable) must remain covered at all times. The "300" target is the one that matters—before the fix, this line would fail (the old code deleted the entire file and rebuilt it using only the result of the second run, so the "300" would disappear). With the fix, Minimizer saves the original test before deleting the file, and when the second evaluation fails to reproduce the "300," it reinserts that original test—so the assertion passes.