### PR TITLE
Fix two bugs in RPCIndividual

### DIFF
--- a/core/src/main/kotlin/org/evomaster/core/problem/rpc/RPCIndividual.kt
+++ b/core/src/main/kotlin/org/evomaster/core/problem/rpc/RPCIndividual.kt
@@ -62,10 +62,17 @@ class RPCIndividual(
                     Lazy.assert { actions.size == externalServicesActions.size }
                 }
                 EnterpriseActionGroup(mutableListOf(rpcCallAction), RPCCallAction::class.java).apply {
-                    addChildrenToGroup(
-                        externalServicesActions[index],
-                        GroupsOfChildren.EXTERNAL_SERVICES
-                    )
+                    /*
+                        externalServicesActions defaults to empty, meaning no call has any
+                        mocked external service. Indexing into it regardless would throw for
+                        every call, making the default unusable.
+                     */
+                    if (index < externalServicesActions.size) {
+                        addChildrenToGroup(
+                            externalServicesActions[index],
+                            GroupsOfChildren.EXTERNAL_SERVICES
+                        )
+                    }
                 }})
         },
         mainSize = actions.size,
@@ -76,7 +83,20 @@ class RPCIndividual(
     override fun canMutateStructure(): Boolean = true
 
 
-    fun seeIndexedRPCCalls(): Map<Int, RPCCallAction> = getIndexedChildren(RPCCallAction::class.java)
+    /**
+     * The RPC calls of this individual, by the index of the child holding each.
+     *
+     * Note the calls are not children of the individual directly: each is wrapped in an
+     * [EnterpriseActionGroup], alongside the external-service actions that belong to it. So
+     * asking for children of type [RPCCallAction] finds nothing, and the group has to be
+     * unwrapped.
+     */
+    fun seeIndexedRPCCalls(): Map<Int, RPCCallAction> =
+        getIndexedChildren(EnterpriseActionGroup::class.java)
+            .mapNotNull { (index, group) ->
+                (group.getMainAction() as? RPCCallAction)?.let { index to it }
+            }
+            .toMap()
 
 
     /**

--- a/core/src/test/kotlin/org/evomaster/core/problem/rpc/RPCIndividualTest.kt
+++ b/core/src/test/kotlin/org/evomaster/core/problem/rpc/RPCIndividualTest.kt
@@ -1,0 +1,73 @@
+package org.evomaster.core.problem.rpc
+
+import org.evomaster.core.problem.api.param.Param
+import org.evomaster.core.problem.enterprise.SampleType
+import org.evomaster.core.problem.rpc.param.RPCParam
+import org.evomaster.core.search.gene.numeric.IntegerGene
+import org.evomaster.core.sql.SqlAction
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Test
+
+class RPCIndividualTest {
+
+    private fun call(id: String) = RPCCallAction(
+        interfaceId = "com.foo.Service",
+        id = id,
+        inputParameters = mutableListOf<Param>(RPCParam("arg", IntegerGene("arg"))),
+        responseTemplate = null,
+        response = null
+    )
+
+    @Test
+    fun testSeeIndexedRPCCalls() {
+
+        val actions = mutableListOf(call("a"), call("b"), call("c"))
+
+        val individual = RPCIndividual(SampleType.RANDOM, actions = actions)
+
+        /*
+            The calls are not children of the individual directly: each is wrapped in an
+            EnterpriseActionGroup. Looking them up by action type therefore finds nothing unless
+            the group is unwrapped.
+         */
+        val indexed = individual.seeIndexedRPCCalls()
+
+        assertEquals(3, indexed.size)
+        assertEquals(listOf("a", "b", "c"), indexed.entries.sortedBy { it.key }.map { it.value.getName() })
+    }
+
+    @Test
+    fun testIndicesAreThoseOfTheChildrenHoldingTheCalls() {
+
+        val actions = mutableListOf(call("a"), call("b"))
+
+        val individual = RPCIndividual(SampleType.RANDOM, actions = actions)
+
+        individual.seeIndexedRPCCalls().forEach { (index, action) ->
+            //the index must address the child that holds the call, not some other numbering
+            assertSame(action, (individual.getViewOfChildren()[index] as Any).let {
+                (it as org.evomaster.core.problem.enterprise.EnterpriseActionGroup<*>).getMainAction()
+            })
+        }
+    }
+
+    @Test
+    fun testCallsAreFoundPastInitializingActions() {
+
+        val actions = mutableListOf(call("a"))
+
+        val individual = RPCIndividual(
+            SampleType.RANDOM,
+            actions = actions,
+            dbInitialization = mutableListOf<SqlAction>()
+        )
+
+        assertEquals(1, individual.seeIndexedRPCCalls().size)
+        assertEquals("a", individual.seeIndexedRPCCalls().values.first().getName())
+    }
+
+    @Test
+    fun testAnIndividualWithNoCalls() {
+        assertTrue(RPCIndividual(SampleType.RANDOM, actions = mutableListOf()).seeIndexedRPCCalls().isEmpty())
+    }
+}


### PR DESCRIPTION
Two bugs in `RPCIndividual`, both found while writing an equivalent individual for another problem type and copying this one's shape. Independent of that work, so sent on its own.

## `seeIndexedRPCCalls` always returns an empty map

```kotlin
fun seeIndexedRPCCalls(): Map<Int, RPCCallAction> = getIndexedChildren(RPCCallAction::class.java)
```

`getIndexedChildren` filters the individual's direct children by type, but the calls are not direct children: the constructor wraps each in an `EnterpriseActionGroup`, alongside the external-service actions belonging to it. So nothing ever matches the filter and the result is always empty.

Compare `RestIndividual.getIndexedResourceCalls`, which works because `RestResourceCalls` really is the child type there.

The method has no callers today, which is presumably why it went unnoticed. The fix unwraps the group.

## The convenience constructor throws whenever it is used without external services

```kotlin
addAll(actions.mapIndexed { index, rpcCallAction ->
    if (externalServicesActions.isNotEmpty()){
        Lazy.assert { actions.size == externalServicesActions.size }
    }
    EnterpriseActionGroup(...).apply {
        addChildrenToGroup(externalServicesActions[index], ...)   // <- not guarded
    }})
```

`externalServicesActions` defaults to an empty list. The `isNotEmpty()` check guards only the assert; the indexing right after it is unguarded, so `externalServicesActions[index]` throws `IndexOutOfBoundsException` on the very first call.

In practice only callers passing a list of matching size work — which is what `EvaluatedIndividualBuilder.buildEvaluatedRPCIndividual` does, so the existing tests never hit it. Constructing an `RPCIndividual` the way the default parameters invite you to fails immediately.

The fix adds the missing bound check, leaving behaviour unchanged when a list is supplied.

## Testing

Adds `RPCIndividualTest`, which the class had none of — four tests covering the indexed lookup, the indices actually addressing the children that hold the calls, calls found past initializing actions, and the empty case. The first of them fails on both bugs before the fix.

`RPCActionNamingStrategyTest`, `TestSuiteWriterRPCTest` and `TestSuiteOrganizerTest` still pass.
