### PR TITLE
Accept the timestamp layouts databases actually emit

### DIFF
--- a/core-extra/dbconstraint/src/main/java/org/evomaster/dbconstraint/parser/jsql/JSqlVisitor.java
+++ b/core-extra/dbconstraint/src/main/java/org/evomaster/dbconstraint/parser/jsql/JSqlVisitor.java
@@ -17,6 +17,11 @@ import java.math.BigInteger;
 import java.sql.Timestamp;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeFormatterBuilder;
+import java.time.temporal.ChronoField;
+import java.time.temporal.TemporalAccessor;
+import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Deque;
@@ -33,7 +38,36 @@ public class JSqlVisitor implements ExpressionVisitor {
 
     private static final String SINGLE_QUOTE_CHAR = "'";
 
-    private static final String TIMESTAMP_FORMAT = "yyyy-MM-dd HH:mm:ss";
+    /**
+     * Accepts the timestamp layouts a database or an ORM actually emits, rather than a single one.
+     *
+     * The date is mandatory; everything after it is optional. The time may be separated by a space
+     * or by the ISO 'T', may omit the seconds, and may carry a fractional part of any precision. A
+     * trailing UTC offset is honoured in either the "+HH:mm"/"Z" or the "+HH" spelling.
+     *
+     * Widening this matters more than it looks: when a literal cannot be read, the resulting
+     * exception makes the caller drop the *whole* WHERE clause, including the conditions it could
+     * otherwise have translated. An ORM emits sub-second precision whenever it compares a column
+     * against the current instant, so the narrow form lost entire clauses routinely.
+     *
+     * The fractional part is parsed but not used: the result is expressed in whole epoch seconds,
+     * matching the decoder in SMTLibZ3DbConstraintSolver.
+     */
+    private static final DateTimeFormatter TIMESTAMP_PARSER = new DateTimeFormatterBuilder()
+            .appendPattern("yyyy-MM-dd")
+            .optionalStart().appendLiteral('T').optionalEnd()
+            .optionalStart().appendLiteral(' ').optionalEnd()
+            .optionalStart()
+            .appendPattern("HH:mm")
+            .optionalStart().appendPattern(":ss").optionalEnd()
+            .optionalStart().appendFraction(ChronoField.NANO_OF_SECOND, 1, 9, true).optionalEnd()
+            .optionalEnd()
+            .optionalStart().appendOffset("+HH:MM", "Z").optionalEnd()
+            .optionalStart().appendOffset("+HH", "Z").optionalEnd()
+            .parseDefaulting(ChronoField.HOUR_OF_DAY, 0)
+            .parseDefaulting(ChronoField.MINUTE_OF_HOUR, 0)
+            .parseDefaulting(ChronoField.SECOND_OF_MINUTE, 0)
+            .toFormatter();
 
     private final Deque<SqlCondition> stack = new ArrayDeque<>();
 
@@ -624,11 +658,12 @@ public class JSqlVisitor implements ExpressionVisitor {
             if (value.startsWith(SINGLE_QUOTE_CHAR) && value.endsWith(SINGLE_QUOTE_CHAR)) {
                 value = value.substring(1, value.length() - 1);
             }
-            // Treat the timestamp string as UTC to match the UTC-based decoder in
-            // SMTLibZ3DbConstraintSolver (LocalDateTime.ofInstant(..., UTC)).
-            long epochSeconds = java.time.LocalDateTime.parse(value,
-                    DateTimeFormatter.ofPattern(TIMESTAMP_FORMAT))
-                    .toEpochSecond(ZoneOffset.UTC);
+            TemporalAccessor parsed = TIMESTAMP_PARSER.parse(value);
+            // An explicit offset is honoured; without one, treat the literal as UTC to match the
+            // UTC-based decoder in SMTLibZ3DbConstraintSolver (LocalDateTime.ofInstant(..., UTC)).
+            long epochSeconds = parsed.isSupported(ChronoField.OFFSET_SECONDS)
+                    ? OffsetDateTime.from(parsed).toEpochSecond()
+                    : LocalDateTime.from(parsed).toEpochSecond(ZoneOffset.UTC);
             stack.push(new SqlBigIntegerLiteralValue(BigInteger.valueOf(epochSeconds)));
             return;
         }

--- a/core-extra/dbconstraint/src/main/java/org/evomaster/dbconstraint/parser/jsql/JSqlVisitor.java
+++ b/core-extra/dbconstraint/src/main/java/org/evomaster/dbconstraint/parser/jsql/JSqlVisitor.java
@@ -53,17 +53,34 @@ public class JSqlVisitor implements ExpressionVisitor {
      * The fractional part is parsed but not used: the result is expressed in whole epoch seconds,
      * matching the decoder in SMTLibZ3DbConstraintSolver.
      */
-    private static final DateTimeFormatter TIMESTAMP_PARSER = new DateTimeFormatterBuilder()
-            .appendPattern("yyyy-MM-dd")
-            .optionalStart().appendLiteral('T').optionalEnd()
-            .optionalStart().appendLiteral(' ').optionalEnd()
-            .optionalStart()
+    /**
+     * The time of day, with everything after the hour and minute optional. Built separately so it can
+     * be attached to each separator as a unit: were the separator and the time independently
+     * optional, a literal consisting of a date and a stray separator would satisfy the pattern and be
+     * silently read as midnight.
+     */
+    private static final DateTimeFormatter TIME_OF_DAY = new DateTimeFormatterBuilder()
             .appendPattern("HH:mm")
             .optionalStart().appendPattern(":ss").optionalEnd()
             .optionalStart().appendFraction(ChronoField.NANO_OF_SECOND, 1, 9, true).optionalEnd()
-            .optionalEnd()
             .optionalStart().appendOffset("+HH:MM", "Z").optionalEnd()
             .optionalStart().appendOffset("+HH", "Z").optionalEnd()
+            .toFormatter();
+
+    private static DateTimeFormatter timeAfter(char separator) {
+        return new DateTimeFormatterBuilder()
+                .appendLiteral(separator)
+                .append(TIME_OF_DAY)
+                .toFormatter();
+    }
+
+    private static final DateTimeFormatter TIMESTAMP_PARSER = new DateTimeFormatterBuilder()
+            .appendPattern("yyyy-MM-dd")
+            // Either separator, each carrying the whole time of day with it, so that neither can
+            // appear without one. A date on its own remains valid; a date with a dangling separator,
+            // or with an offset but no time, does not.
+            .appendOptional(timeAfter('T'))
+            .appendOptional(timeAfter(' '))
             .parseDefaulting(ChronoField.HOUR_OF_DAY, 0)
             .parseDefaulting(ChronoField.MINUTE_OF_HOUR, 0)
             .parseDefaulting(ChronoField.SECOND_OF_MINUTE, 0)

--- a/core/src/main/kotlin/org/evomaster/core/database/sql/solver/SMTLibZ3DbConstraintSolver.kt
+++ b/core/src/main/kotlin/org/evomaster/core/database/sql/solver/SMTLibZ3DbConstraintSolver.kt
@@ -80,8 +80,9 @@ class SMTLibZ3DbConstraintSolver() : DbConstraintSolver {
     companion object {
         private const val MAX_CACHE_SIZE = 500
 
-        // Must match the timestamp format used by JSqlVisitor (TIMESTAMP_FORMAT) so that
-        // epoch<->string conversions round-trip consistently.
+        // The single layout emitted when turning an epoch value back into a SQL literal. JSqlVisitor
+        // reads a superset of the layouts a database may emit, of which this is one, so the value
+        // round-trips: what is written here is read back to the same instant.
         private const val TIMESTAMP_FORMAT = "yyyy-MM-dd HH:mm:ss"
     }
 

--- a/core/src/test/kotlin/org/evomaster/core/solver/WhereClauseTranslationLimitsTest.kt
+++ b/core/src/test/kotlin/org/evomaster/core/solver/WhereClauseTranslationLimitsTest.kt
@@ -3,10 +3,9 @@ package org.evomaster.core.solver
 import org.evomaster.dbconstraint.ConstraintDatabaseType
 import org.evomaster.dbconstraint.parser.jsql.JSqlConditionParser
 import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
-import org.evomaster.core.database.sql.solver.SmtLibGenerator
-import org.evomaster.core.database.sql.solver.SMTConditionVisitor
 
 /**
  * Pins what a WHERE clause is allowed to contain on its way to the solver, and in particular the two
@@ -61,6 +60,30 @@ class WhereClauseTranslationLimitsTest {
         assertEpoch("T > TIMESTAMP '2026-08-18 06:25:20.351123456'", 1787034320)
         assertEpoch("T > TIMESTAMP '2026-08-18 06:25'", 1787034300)
         assertEpoch("T > TIMESTAMP '2026-08-18'", 1787011200)
+    }
+
+    /**
+     * The layouts accepted are a set, not a prefix rule. A separator carries the time of day with it,
+     * so a date followed by a dangling `T` or space is rejected rather than silently read as midnight,
+     * and an offset without a time is rejected too. Getting this wrong is invisible at runtime: the
+     * literal would parse, the condition would translate, and the comparison would be against the
+     * wrong instant.
+     */
+    @Test
+    fun `a dangling separator or a bare offset is rejected`() {
+        listOf(
+            "2026-08-18T",          // separador sin hora
+            "2026-08-18 ",          // espacio sin hora
+            "2026-08-18+02:00",     // offset sin hora
+            "2026-08-18T 06:25"     // los dos separadores a la vez
+        ).forEach { literal ->
+            // RuntimeException rather than a narrower type: what matters is that it throws at all,
+            // and that the exception is one the generateSMT guard already catches, so the query is
+            // dropped and counted rather than translated against a wrong instant.
+            assertThrows(RuntimeException::class.java, {
+                parser.parse("(VALID_TO > TIMESTAMP '$literal')", ConstraintDatabaseType.POSTGRES)
+            }, "'$literal' is not a timestamp layout and must not be accepted")
+        }
     }
 
     /** An explicit offset is honoured rather than ignored, in both spellings. */

--- a/core/src/test/kotlin/org/evomaster/core/solver/WhereClauseTranslationLimitsTest.kt
+++ b/core/src/test/kotlin/org/evomaster/core/solver/WhereClauseTranslationLimitsTest.kt
@@ -1,0 +1,105 @@
+package org.evomaster.core.solver
+
+import org.evomaster.dbconstraint.ConstraintDatabaseType
+import org.evomaster.dbconstraint.parser.jsql.JSqlConditionParser
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertDoesNotThrow
+import org.evomaster.core.database.sql.solver.SmtLibGenerator
+import org.evomaster.core.database.sql.solver.SMTConditionVisitor
+
+/**
+ * Pins what a WHERE clause is allowed to contain on its way to the solver, and in particular the two
+ * ways a condition can still be lost.
+ *
+ * Both matter because the consequence is the same and is silent: the constraint never reaches Z3,
+ * the weakened formula stays satisfiable, the solver answers `SAT`, and the rows it produces need
+ * not satisfy the query that triggered the call. Nothing downstream distinguishes those rows from
+ * correct ones.
+ *
+ * The two paths differ in whether anything notices:
+ *
+ *  - A condition the parser rejects raises an exception, which `SmtLibGenerator` catches while
+ *    discarding **the entire WHERE clause** — not only the sub-expression it could not read. This
+ *    increments the partial-translation counter, so it is at least visible in the statistics.
+ *  - A condition the parser accepts but the visitor cannot translate is dropped by returning an
+ *    empty node. No exception, no counter, no trace.
+ */
+class WhereClauseTranslationLimitsTest {
+
+    private val parser = JSqlConditionParser()
+
+    private fun parse(where: String) = parser.parse(where, ConstraintDatabaseType.H2)
+
+    /**
+     * Timestamp literals are converted to whole epoch seconds, so a parsed condition carries the
+     * epoch as a literal. Comparing against it checks the conversion, not merely that parsing
+     * succeeded — a formatter can accept a string and still read it wrongly.
+     */
+    private fun assertEpoch(where: String, expected: Long) {
+        val rendered = assertDoesNotThrow("expected '$where' to parse") { parse(where) }.toString()
+        assertTrue(rendered.contains(expected.toString())) {
+            "expected '$where' to yield epoch $expected, got: $rendered"
+        }
+    }
+
+    /**
+     * The layouts a database or an ORM emits in practice: with or without an ISO `T`, with or
+     * without seconds, with any fractional precision, and with a trailing offset.
+     *
+     * Before these were accepted, each one raised an exception that discarded the whole WHERE
+     * clause. Sub-second precision is the common case, since it appears whenever a query compares a
+     * column against the current instant.
+     */
+    @Test
+    fun `timestamp literals are accepted in the layouts databases emit`() {
+        assertEpoch("T > TIMESTAMP '2026-08-18 06:25:20'", 1787034320)
+        assertEpoch("T > TIMESTAMP '2026-08-18T06:25:20'", 1787034320)
+        assertEpoch("T > TIMESTAMP '2026-08-18 06:25:20.3'", 1787034320)
+        assertEpoch("T > TIMESTAMP '2026-08-18 06:25:20.351'", 1787034320)
+        assertEpoch("T > TIMESTAMP '2026-08-18 06:25:20.351123'", 1787034320)
+        assertEpoch("T > TIMESTAMP '2026-08-18 06:25:20.351123456'", 1787034320)
+        assertEpoch("T > TIMESTAMP '2026-08-18 06:25'", 1787034300)
+        assertEpoch("T > TIMESTAMP '2026-08-18'", 1787011200)
+    }
+
+    /** An explicit offset is honoured rather than ignored, in both spellings. */
+    @Test
+    fun `timestamp offsets are honoured`() {
+        assertEpoch("T > TIMESTAMP '2026-08-18 06:25:20+02:00'", 1787027120)
+        assertEpoch("T > TIMESTAMP '2026-08-18 06:25:20+02'", 1787027120)
+        assertEpoch("T > TIMESTAMP '2026-08-18 06:25:20Z'", 1787034320)
+    }
+
+    /** Everyday conditions parse, so any remaining limitation is specific rather than general. */
+    @Test
+    fun `ordinary conditions are accepted`() {
+        listOf(
+            "ID = 42",
+            "NAME = 'alice'",
+            "ACTIVE = TRUE",
+            "SCORE >= 4.5",
+            "LEVEL > 3 AND LEVEL <= 10",
+            "ID IN (1, 2, 3)",
+            "NAME LIKE 'a%'",
+            "LOWER(NAME) LIKE 'a%'",
+            "UPPER(NAME) = 'ALICE'",
+            "RANK < 50 OR TITLE = 'draft'"
+        ).forEach { where -> assertDoesNotThrow("expected '$where' to parse") { parse(where) } }
+    }
+
+    /**
+     * Null checks parse cleanly, which is precisely why their loss is invisible: they are discarded
+     * later, by the visitor, without raising anything and without touching any counter. Should
+     * `SMTConditionVisitor` learn to translate them, this test keeps documenting where the boundary
+     * used to be.
+     */
+    @Test
+    fun `null checks parse but are dropped later without a trace`() {
+        listOf(
+            "VALID_TO IS NULL",
+            "VALID_TO IS NOT NULL",
+            "VALID_TO IS NULL OR N > 3"
+        ).forEach { where -> assertDoesNotThrow("expected '$where' to parse") { parse(where) } }
+    }
+}


### PR DESCRIPTION
Part of the work in #1688, split into one change per defect. That PR stays open as the umbrella: it carries the full diagnosis and the measurements behind each of these.

## The defect

`JSqlVisitor` accepted exactly one timestamp layout, `yyyy-MM-dd HH:mm:ss`, and threw on anything else.

That exception is caught around the translation of the **whole** WHERE clause, so a single unreadable literal discarded every other condition in the query — including the ones that translated fine. The query was then handed to the solver under-constrained, or dropped entirely.

The case is not exotic. An ORM emits sub-second precision whenever it compares a column against the current instant. In a capture of real traffic from one system under test, 7% of distinct queries carried such a literal.

## The change

`JSqlVisitor` now parses with a `DateTimeFormatterBuilder` covering the layouts databases actually produce:

- date only, `2026-05-20`
- with or without seconds
- any fractional precision, `2026-05-20 10:15:30.123456789`
- the ISO `T` separator
- a trailing offset, which is **honoured** rather than ignored — an offset-carrying literal now converts through `OffsetDateTime`, so the epoch value is correct instead of being off by the offset

Missing fields default to zero, which preserves the previous behaviour for the one layout that already worked.

## Tests

`WhereClauseTranslationLimitsTest` covers the accepted layouts and the offset handling, and pins what is still rejected so the boundary is explicit rather than incidental.

Verified with `mvn clean verify -DskipTests --fae` and the `dbconstraint` and `core` solver suites.