### PR TITLE
Let each SQL data strategy evaluate its own precondition

### DIFF
--- a/core/src/main/kotlin/org/evomaster/core/problem/api/service/ApiWsStructureMutator.kt
+++ b/core/src/main/kotlin/org/evomaster/core/problem/api/service/ApiWsStructureMutator.kt
@@ -57,8 +57,10 @@ abstract class ApiWsStructureMutator : StructureMutator() {
          * inconsistency is fixed because it is one, not because it was shown to have suppressed
          * anything.
          *
-         * The precedence mirrors [handleFailedWhereSQL]: the search-based strategy wins when both are
-         * enabled, so the solver's own precondition only applies when it is the one that will run.
+         * The two are mutually exclusive — [EMConfig] rejects a configuration with both enabled — so
+         * the order below is not a precedence rule but a total definition: with neither strategy
+         * enabled there is nothing to do whatever the inputs say, which keeps the predicate honest
+         * independently of the `shouldGenerateSqlData` check that currently guards the call site.
          */
         internal fun nothingToDoForFailedWhere(
             noInsertableTables: Boolean,
@@ -66,8 +68,9 @@ abstract class ApiWsStructureMutator : StructureMutator() {
             generateSqlDataWithSearch: Boolean,
             generateSqlDataWithZ3: Boolean
         ): Boolean {
-            val solverWillRun = generateSqlDataWithZ3 && !generateSqlDataWithSearch
-            return if (solverWillRun) noFailedWhereQueries else noInsertableTables
+            if (generateSqlDataWithSearch) return noInsertableTables
+            if (generateSqlDataWithZ3) return noFailedWhereQueries
+            return true
         }
     }
 

--- a/core/src/main/kotlin/org/evomaster/core/problem/api/service/ApiWsStructureMutator.kt
+++ b/core/src/main/kotlin/org/evomaster/core/problem/api/service/ApiWsStructureMutator.kt
@@ -42,6 +42,33 @@ abstract class ApiWsStructureMutator : StructureMutator() {
 
     companion object {
         private val log: Logger = LoggerFactory.getLogger(ApiWsStructureMutator::class.java)
+
+        /**
+         * Whether there is nothing to do for a failed WHERE, which depends on the strategy because
+         * the two consume different inputs.
+         *
+         * The search-based generation builds INSERTs table by table, so it needs tables it is able to
+         * insert into; with none, there is nothing it can do. The solver instead works from the query
+         * text and the schema, and never consults that map. Gating it on the map made it inherit a
+         * precondition that is not its own: a failed WHERE over something canInsertInto rejects — a
+         * view, or a table whose identifier does not match the schema exactly — would leave the solver
+         * unreachable even though the query is there and translatable, and would do so without leaving
+         * any trace in the statistics. No case of that actually happening was observed; the
+         * inconsistency is fixed because it is one, not because it was shown to have suppressed
+         * anything.
+         *
+         * The precedence mirrors [handleFailedWhereSQL]: the search-based strategy wins when both are
+         * enabled, so the solver's own precondition only applies when it is the one that will run.
+         */
+        internal fun nothingToDoForFailedWhere(
+            noInsertableTables: Boolean,
+            noFailedWhereQueries: Boolean,
+            generateSqlDataWithSearch: Boolean,
+            generateSqlDataWithZ3: Boolean
+        ): Boolean {
+            val solverWillRun = generateSqlDataWithZ3 && !generateSqlDataWithSearch
+            return if (solverWillRun) noFailedWhereQueries else noInsertableTables
+        }
     }
 
     // TODO: This will moved under ApiWsFitness once RPC and GraphQL support is completed
@@ -308,13 +335,25 @@ abstract class ApiWsStructureMutator : StructureMutator() {
             //TODO likely to remove/change once we ll support VIEWs
             .filter { sampler.canInsertInto(it.key) }
 
-        if (fw.isEmpty()) {
+        val failedWhereQueries = evaluatedIndividual.fitness.getViewOfAggregatedFailedWhereQueries()
+
+        val nothingToDo = nothingToDoForFailedWhere(
+            noInsertableTables = fw.isEmpty(),
+            noFailedWhereQueries = failedWhereQueries.isEmpty(),
+            generateSqlDataWithSearch = config.generateSqlDataWithSearch,
+            generateSqlDataWithZ3 = config.generateSqlDataWithZ3
+        )
+        if (nothingToDo) {
+            if (log.isTraceEnabled && fw.isEmpty() && failedWhereQueries.isNotEmpty()) {
+                log.trace(
+                    "{} failed WHERE queries were reported, but no table among them can be inserted into",
+                    failedWhereQueries.size
+                )
+            }
             return
         }
 
         val oldSqlActions = mutableListOf<EnvironmentAction>().plus(ind.seeInitializingActions())
-
-        val failedWhereQueries = evaluatedIndividual.fitness.getViewOfAggregatedFailedWhereQueries()
         val addedSqlInsertions = handleFailedWhereSQL(ind, fw, failedWhereQueries, mutatedGenes, sampler)
 
         ind.repairInitializationActions(randomness)

--- a/core/src/test/kotlin/org/evomaster/core/problem/api/service/FailedWhereStrategyGateTest.kt
+++ b/core/src/test/kotlin/org/evomaster/core/problem/api/service/FailedWhereStrategyGateTest.kt
@@ -38,11 +38,22 @@ class FailedWhereStrategyGateTest {
         )
     }
 
+    /**
+     * Defensive, not reachable: EMConfig rejects a configuration with both strategies enabled. Pinned
+     * anyway so the predicate stays total, since it is a pure function that a future caller could
+     * reach without that validation in front of it.
+     */
     @Test
     fun `with both strategies enabled the search-based precondition is the one that applies`() {
-        // Mirrors handleFailedWhereSQL, where the search-based branch returns first.
         assertTrue(gate(noInsertableTables = true, noFailedWhereQueries = false, search = true, z3 = true))
         assertFalse(gate(noInsertableTables = false, noFailedWhereQueries = true, search = true, z3 = true))
+    }
+
+    /** With no strategy enabled there is nothing to do, whatever the inputs say. */
+    @Test
+    fun `with neither strategy enabled there is nothing to do`() {
+        assertTrue(gate(noInsertableTables = false, noFailedWhereQueries = false, search = false, z3 = false))
+        assertTrue(gate(noInsertableTables = true, noFailedWhereQueries = true, search = false, z3 = false))
     }
 
     @Test

--- a/core/src/test/kotlin/org/evomaster/core/problem/api/service/FailedWhereStrategyGateTest.kt
+++ b/core/src/test/kotlin/org/evomaster/core/problem/api/service/FailedWhereStrategyGateTest.kt
@@ -1,0 +1,62 @@
+package org.evomaster.core.problem.api.service
+
+import org.evomaster.core.problem.api.service.ApiWsStructureMutator.Companion.nothingToDoForFailedWhere
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+/**
+ * The two SQL data generation strategies consume different inputs, so what counts as "nothing to do"
+ * for a failed WHERE is not the same for both.
+ *
+ * The case that matters is a search reporting failed WHERE queries where none of the tables involved
+ * can be inserted into. The search-based strategy genuinely has nothing to do there; the solver, which
+ * reads the query text rather than that map, does.
+ */
+class FailedWhereStrategyGateTest {
+
+    private fun gate(
+        noInsertableTables: Boolean,
+        noFailedWhereQueries: Boolean,
+        search: Boolean,
+        z3: Boolean
+    ) = nothingToDoForFailedWhere(noInsertableTables, noFailedWhereQueries, search, z3)
+
+    @Test
+    fun `the solver runs on queries whose tables cannot be inserted into`() {
+        assertFalse(
+            gate(noInsertableTables = true, noFailedWhereQueries = false, search = false, z3 = true),
+            "the solver reads the query text, so an empty insertable-table map must not stop it"
+        )
+    }
+
+    @Test
+    fun `the search-based strategy stops when no table can be inserted into`() {
+        assertTrue(
+            gate(noInsertableTables = true, noFailedWhereQueries = false, search = true, z3 = false),
+            "the search builds INSERTs table by table, so with no table it has nothing to do"
+        )
+    }
+
+    @Test
+    fun `with both strategies enabled the search-based precondition is the one that applies`() {
+        // Mirrors handleFailedWhereSQL, where the search-based branch returns first.
+        assertTrue(gate(noInsertableTables = true, noFailedWhereQueries = false, search = true, z3 = true))
+        assertFalse(gate(noInsertableTables = false, noFailedWhereQueries = true, search = true, z3 = true))
+    }
+
+    @Test
+    fun `neither strategy runs without input of its own kind`() {
+        assertTrue(gate(noInsertableTables = true, noFailedWhereQueries = true, search = false, z3 = true))
+        assertTrue(gate(noInsertableTables = true, noFailedWhereQueries = true, search = true, z3 = false))
+    }
+
+    @Test
+    fun `each strategy ignores the other's input`() {
+        // Queries present but no insertable table: only the solver proceeds.
+        assertFalse(gate(noInsertableTables = true, noFailedWhereQueries = false, search = false, z3 = true))
+        // Insertable tables present but no query text recorded: only the search proceeds.
+        assertFalse(gate(noInsertableTables = false, noFailedWhereQueries = true, search = true, z3 = false))
+        assertTrue(gate(noInsertableTables = false, noFailedWhereQueries = true, search = false, z3 = true))
+    }
+}


### PR DESCRIPTION
Part of the work in #1688, split into one change per defect.

**This is a latent defect.** No case was observed where it actually suppressed an invocation. It is corrected because it is a real inconsistency and the correction is small — not because any observed experimental result is attributed to it. Flagging that up front so it is reviewed on its own merits.

## The inconsistency

Before deciding whether there is any work to do for a failed WHERE clause, `ApiWsStructureMutator` builds the failed-WHERE map grouped per table and filtered by what the sampler can insert into. If that map comes out empty, it returns.

That is the correct precondition for the **search-based** strategy: it builds `INSERT` statements table by table, so with no table it genuinely has nothing to do.

The **constraint solver** does not consume that map at all. It works from the query text and the schema. Sharing one entry point made it inherit a precondition that is not its own.

The consequence, if it were hit: a failed WHERE over something the filter rejects — a view, or a table whose identifier does not match the schema exactly — would leave the solver unreachable even though there is a query recorded and translatable. And it would do so silently, since no counter is incremented, making the case indistinguishable in the statistics from a system that simply issues no failing queries.

## The change

Each strategy now evaluates its own precondition. The precedence mirrors what `handleFailedWhereSQL` already does — the search-based strategy wins when both are enabled — so the solver's precondition only applies when the solver is the one that will actually run.

The predicate is extracted as a pure function so it can be tested without constructing an individual, a sampler and a fitness value.

## Tests

`FailedWhereStrategyGateTest` covers each strategy in isolation, the precedence when both are enabled, and that neither runs without input of its own kind.

Verified with `mvn clean verify -DskipTests --fae`.