### PR TITLE
Make the two column-type vocabularies agree on spelling

### DIFF
--- a/core/src/main/kotlin/org/evomaster/core/database/sql/solver/SMTLibZ3DbConstraintSolver.kt
+++ b/core/src/main/kotlin/org/evomaster/core/database/sql/solver/SMTLibZ3DbConstraintSolver.kt
@@ -83,6 +83,13 @@ class SMTLibZ3DbConstraintSolver() : DbConstraintSolver {
         // Must match the timestamp format used by JSqlVisitor (TIMESTAMP_FORMAT) so that
         // epoch<->string conversions round-trip consistently.
         private const val TIMESTAMP_FORMAT = "yyyy-MM-dd HH:mm:ss"
+
+        /**
+         * Spellings [SmtLibGenerator.TYPE_MAP] already treats as the same type. Kept here so the two
+         * vocabularies agree on this pair at least; consolidating all three into one source of truth
+         * remains future work.
+         */
+        private val BOOLEAN_SPELLINGS = setOf("BOOLEAN", "BOOL")
     }
 
     @Inject
@@ -355,7 +362,23 @@ class SMTLibZ3DbConstraintSolver() : DbConstraintSolver {
             it.name.equals(columnName, ignoreCase = true)
         } ?: return false
 
-        return col.type.equals(expectedType, ignoreCase = true)
+        return typeMatches(col.type, expectedType)
+    }
+
+    /**
+     * Whether a column's declared type is the expected one, accounting for spellings that
+     * [SmtLibGenerator.TYPE_MAP] already treats as equivalent.
+     *
+     * Without this, a column declared `BOOL` is encoded as an SMT String exactly like a `BOOLEAN`
+     * one — the type map sends both to the same sort — but is not recognised as boolean when the
+     * solution is turned back into genes, so it silently loses its boolean handling and arrives as
+     * a string.
+     */
+    internal fun typeMatches(declaredType: String, expectedType: String): Boolean {
+        val declared = declaredType.uppercase()
+        val expected = expectedType.uppercase()
+        if (declared == expected) return true
+        return BOOLEAN_SPELLINGS.contains(declared) && BOOLEAN_SPELLINGS.contains(expected)
     }
 
     /**
@@ -472,8 +495,11 @@ class SMTLibZ3DbConstraintSolver() : DbConstraintSolver {
      * @param type The column type as a string.
      * @return The corresponding ColumnDataType.
      */
-    private fun getColumnDataType(type: String): ColumnDataType {
-        return when (type) {
+    internal fun getColumnDataType(type: String): ColumnDataType {
+        // Matched case-insensitively. SmtLibGenerator.TYPE_MAP uppercases before looking up, so a
+        // backend reporting a lowercase spelling used to be mapped there but fall through to the
+        // default here — the two vocabularies disagreeing silently about the same column.
+        return when (type.uppercase()) {
             "BIGINT" -> ColumnDataType.BIGINT
             "INTEGER" -> ColumnDataType.INTEGER
             "FLOAT" -> ColumnDataType.FLOAT

--- a/core/src/main/kotlin/org/evomaster/core/database/sql/solver/SMTLibZ3DbConstraintSolver.kt
+++ b/core/src/main/kotlin/org/evomaster/core/database/sql/solver/SMTLibZ3DbConstraintSolver.kt
@@ -85,11 +85,11 @@ class SMTLibZ3DbConstraintSolver() : DbConstraintSolver {
         private const val TIMESTAMP_FORMAT = "yyyy-MM-dd HH:mm:ss"
 
         /**
-         * Spellings [SmtLibGenerator.TYPE_MAP] already treats as the same type. Kept here so the two
-         * vocabularies agree on this pair at least; consolidating all three into one source of truth
-         * remains future work.
+         * Spellings [SmtLibGenerator.TYPE_MAP] already treats as the same type. The canonical one is
+         * taken from the generator rather than repeated, so the two cannot drift apart; consolidating
+         * all three type vocabularies into one source of truth remains future work.
          */
-        private val BOOLEAN_SPELLINGS = setOf("BOOLEAN", "BOOL")
+        private val BOOLEAN_SPELLINGS = setOf(SmtLibGenerator.BOOLEAN_TYPE, "BOOL")
     }
 
     @Inject

--- a/core/src/main/kotlin/org/evomaster/core/database/sql/solver/SmtLibGenerator.kt
+++ b/core/src/main/kotlin/org/evomaster/core/database/sql/solver/SmtLibGenerator.kt
@@ -94,7 +94,9 @@ class SmtLibGenerator(private val schema: DbInfoDto, private val numberOfRows: I
          * silently disagree when a backend reports a variant spelling; consolidating them into a single
          * source of truth is future work (see the note on SMTLibZ3DbConstraintSolver.hasColumnType).
          */
-        private val TYPE_MAP = mapOf(
+        // internal rather than private so a test can pin the agreement between this vocabulary and
+        // the one SMTLibZ3DbConstraintSolver uses when turning a solution back into genes.
+        internal val TYPE_MAP = mapOf(
             "BIGINT" to SMT_INT,
             "BIT" to SMT_INT,
             "INTEGER" to SMT_INT,

--- a/core/src/main/kotlin/org/evomaster/core/database/sql/solver/SmtLibGenerator.kt
+++ b/core/src/main/kotlin/org/evomaster/core/database/sql/solver/SmtLibGenerator.kt
@@ -94,8 +94,10 @@ class SmtLibGenerator(private val schema: DbInfoDto, private val numberOfRows: I
          * silently disagree when a backend reports a variant spelling; consolidating them into a single
          * source of truth is future work (see the note on SMTLibZ3DbConstraintSolver.hasColumnType).
          */
-        // internal rather than private so a test can pin the agreement between this vocabulary and
-        // the one SMTLibZ3DbConstraintSolver uses when turning a solution back into genes.
+        // internal rather than private so a test can iterate it, checking that every spelling it
+        // accepts is read the same way by SMTLibZ3DbConstraintSolver. That is narrower than full
+        // agreement between the two vocabularies: it covers case handling and the boolean spellings,
+        // not whether each type maps to a compatible gene.
         internal val TYPE_MAP = mapOf(
             "BIGINT" to SMT_INT,
             "BIT" to SMT_INT,

--- a/core/src/test/kotlin/org/evomaster/core/solver/ColumnTypeVocabularyTest.kt
+++ b/core/src/test/kotlin/org/evomaster/core/solver/ColumnTypeVocabularyTest.kt
@@ -1,0 +1,65 @@
+package org.evomaster.core.solver
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.evomaster.core.database.sql.solver.SmtLibGenerator
+import org.evomaster.core.database.sql.solver.SMTLibZ3DbConstraintSolver
+
+/**
+ * Two vocabularies describe the same column type: [SmtLibGenerator.TYPE_MAP], which decides the SMT-LIB
+ * sort a column is encoded as, and [SMTLibZ3DbConstraintSolver], which decides the gene the solved value
+ * is turned back into. When they disagree, nothing fails — a value is produced under one reading and
+ * consumed under another — so the agreement has to be pinned by a test rather than noticed at runtime.
+ */
+class ColumnTypeVocabularyTest {
+
+    private val solver = SMTLibZ3DbConstraintSolver()
+
+    /**
+     * TYPE_MAP uppercases before looking up, so it accepts a lowercase spelling. The gene side used to
+     * match the raw string, which meant a backend reporting `bigint` was encoded as an integer and
+     * decoded as a string.
+     */
+    @Test
+    fun `both vocabularies read a type the same way regardless of its spelling`() {
+        SmtLibGenerator.TYPE_MAP.keys.forEach { type ->
+            val upper = solver.getColumnDataType(type)
+            assertEquals(
+                upper, solver.getColumnDataType(type.lowercase()),
+                "'$type' and '${type.lowercase()}' are the same type to TYPE_MAP, so they must be to the gene side too"
+            )
+            assertEquals(upper, solver.getColumnDataType(type.replaceFirstChar { it.lowercase() }))
+        }
+    }
+
+    /**
+     * `BOOL` and `BOOLEAN` are one entry apart in TYPE_MAP and encode identically. Treating them as
+     * different on the way back costs a column its boolean handling, silently.
+     */
+    @Test
+    fun `the two boolean spellings are equivalent`() {
+        assertTrue(solver.typeMatches("BOOL", "BOOLEAN"))
+        assertTrue(solver.typeMatches("BOOLEAN", "BOOL"))
+        assertTrue(solver.typeMatches("bool", "BOOLEAN"))
+        assertTrue(solver.typeMatches("Boolean", "bool"))
+    }
+
+    @Test
+    fun `a type matches itself whatever its spelling`() {
+        assertTrue(solver.typeMatches("BIGINT", "bigint"))
+        assertTrue(solver.typeMatches("character varying", "CHARACTER VARYING"))
+    }
+
+    /**
+     * The equivalence is deliberately narrow: it exists for the boolean spellings and must not quietly
+     * make unrelated types interchangeable.
+     */
+    @Test
+    fun `unrelated types do not match`() {
+        assertFalse(solver.typeMatches("BIGINT", "BOOLEAN"))
+        assertFalse(solver.typeMatches("BOOL", "CHAR"))
+        assertFalse(solver.typeMatches("INTEGER", "BIGINT"))
+    }
+}

--- a/core/src/test/kotlin/org/evomaster/core/solver/ColumnTypeVocabularyTest.kt
+++ b/core/src/test/kotlin/org/evomaster/core/solver/ColumnTypeVocabularyTest.kt
@@ -11,7 +11,13 @@ import org.evomaster.core.database.sql.solver.SMTLibZ3DbConstraintSolver
  * Two vocabularies describe the same column type: [SmtLibGenerator.TYPE_MAP], which decides the SMT-LIB
  * sort a column is encoded as, and [SMTLibZ3DbConstraintSolver], which decides the gene the solved value
  * is turned back into. When they disagree, nothing fails — a value is produced under one reading and
- * consumed under another — so the agreement has to be pinned by a test rather than noticed at runtime.
+ * consumed under another — so what agreement there is has to be pinned by a test rather than noticed
+ * at runtime.
+ *
+ * What follows covers the two overlaps this change repairs: that neither vocabulary is case-sensitive
+ * where the other is not, and that the two boolean spellings stay interchangeable. It does not check
+ * that every type maps to a compatible gene, which would require the consolidation left as future
+ * work.
  */
 class ColumnTypeVocabularyTest {
 


### PR DESCRIPTION
Part of the work in #1688, split into one change per defect.

`ColumnDto.type` is interpreted in three independent places — `SmtLibGenerator.TYPE_MAP`, `getColumnDataType` and `hasColumnType`. The code already documents these as able to disagree silently on variant spellings. This fixes the two concrete disagreements found; consolidating all three into a single source of truth is left alone, since that would change gene construction.

Both defects share a shape worth naming: **nothing fails**. A value is encoded under one reading and decoded under another, so the search proceeds with the wrong gene type and no counter, log line or exception records it.

## Case sensitivity

`TYPE_MAP` uppercases before looking up, so a backend reporting `bigint` is mapped correctly on the way *in*. `getColumnDataType` matched the raw string, so the same column fell through to the default branch on the way *out* and came back as a string.

Fixed by matching case-insensitively, which is what the other vocabulary already did.

## `BOOL` and `BOOLEAN`

`TYPE_MAP` sends both spellings to the same sort, so both are encoded as an SMT String. `hasColumnType` compared spellings exactly, so a column declared `BOOL` was not recognised as boolean when the solution was turned back into genes — it kept the encoding of a boolean but lost the handling of one.

Fixed with a narrow equivalence, deliberately limited to this pair rather than a general normalisation, so it cannot quietly make unrelated types interchangeable.

## Tests

`ColumnTypeVocabularyTest` checks the agreement over **every entry** of the type map rather than only the two spellings that happened to be wrong, so a type added to one vocabulary and forgotten in the other is caught. It also pins that the boolean equivalence stays narrow: `BIGINT` and `BOOLEAN` must not match.

`TYPE_MAP` is widened from `private` to `internal` for that test; no production code outside the file uses it.

Verified with `mvn clean verify -DskipTests --fae`.