### PR TITLE
Translate ANY and ARRAY in the visitor instead of rewriting them with regexes

### DIFF
--- a/core-extra/dbconstraint/src/main/java/org/evomaster/dbconstraint/parser/jsql/JSqlConditionParser.java
+++ b/core-extra/dbconstraint/src/main/java/org/evomaster/dbconstraint/parser/jsql/JSqlConditionParser.java
@@ -95,11 +95,15 @@ public class JSqlConditionParser implements SqlConditionParser {
          * failing on "ANY ((" before it reaches the array. The uncast spellings need no rewriting,
          * since JSqlVisitor translates them directly.
          *
+         * The cast target is matched as a sequence of words, not a single one: PostgreSQL spells
+         * types like "character varying" and "double precision" with a space, and a pattern that
+         * accepted only one word silently skipped those constraints.
+         *
          * TODO Removable once JSQLParser parses the cast form. The expression would then be an
          * EqualsTo over an ANY function, which JSqlVisitor already handles.
          */
         String transformedStr = originalSqlStr.replaceAll(
-                "=\\s*ANY\\s*\\(\\s*\\(\\s*ARRAY\\s*\\[([^\\]]*)\\]\\s*\\)\\s*::\\s*\\w+\\s*\\[\\s*\\]\\s*\\)",
+                "=\\s*ANY\\s*\\(\\s*\\(\\s*ARRAY\\s*\\[([^\\]]*)\\]\\s*\\)\\s*::\\s*\\w+(?:\\s+\\w+)*\\s*\\[\\s*\\]\\s*\\)",
                 " IN ($1)");
 
         /*

--- a/core-extra/dbconstraint/src/main/java/org/evomaster/dbconstraint/parser/jsql/JSqlConditionParser.java
+++ b/core-extra/dbconstraint/src/main/java/org/evomaster/dbconstraint/parser/jsql/JSqlConditionParser.java
@@ -77,10 +77,10 @@ public class JSqlConditionParser implements SqlConditionParser {
     /**
      * Rewrites dialect constructs into constructs the rest of the pipeline can consume.
      *
-     * <p>Each rule below exists for one of two reasons, and the distinction decides whether it can
-     * ever be removed. Some constructs JSQLParser cannot parse at all. Others parse fine but produce
-     * AST nodes {@link JSqlVisitor} does not translate, and no parser upgrade changes that. Each
-     * rule states which case it is.
+     * <p>Every rule here is a parser limitation: JSQLParser cannot read the construct at all, so it
+     * is rewritten into one the library accepts. Constructs the library parses are left alone, even
+     * when they are dialect-specific, because {@link JSqlVisitor} translates them from the AST where
+     * the intent is explicit rather than guessed at from the text.
      *
      * @param originalSqlStr original string before transforming dialect primitives
      * @return the transformed SQL so JSQLParser can handle it
@@ -91,56 +91,16 @@ public class JSqlConditionParser implements SqlConditionParser {
          *
          *     (col)::text = ANY ((ARRAY['A'::character varying, 'B'::character varying])::text[])
          *
-         * Handled ahead of the general rules below because the two of them, applied to this shape,
-         * used to leave the cast's own brackets unbalanced: the ARRAY rule ran to the last "]" in the
-         * string, which belongs to "::text[]" rather than to the array, and turned it into "::text[".
-         * The result was invalid SQL, so the constraint was discarded — but only after JSQLParser had
-         * spent a very long time backtracking over it. On one real schema, 44 of 48 check constraints
-         * failed this way and cost over five minutes of the search budget between them, with a single
-         * 24 KB constraint accounting for 275 seconds of that.
-         *
          * A parser limitation: JSQLParser 4.9 rejects the parenthesised expression inside ANY,
-         * failing on "ANY ((" before it reaches the array.
+         * failing on "ANY ((" before it reaches the array. The uncast spellings need no rewriting,
+         * since JSqlVisitor translates them directly.
          *
-         * TODO A parser that accepts the shape does not by itself make this rule removable. The
-         * expression would then be an EqualsTo over an ANY function, which JSqlVisitor does not
-         * translate either, so both have to handle it first.
+         * TODO Removable once JSQLParser parses the cast form. The expression would then be an
+         * EqualsTo over an ANY function, which JSqlVisitor already handles.
          */
         String transformedStr = originalSqlStr.replaceAll(
                 "=\\s*ANY\\s*\\(\\s*\\(\\s*ARRAY\\s*\\[([^\\]]*)\\]\\s*\\)\\s*::\\s*\\w+\\s*\\[\\s*\\]\\s*\\)",
                 " IN ($1)");
-
-        /*
-         * PostgreSQL's "= ANY (...)" is rewritten to the equivalent " IN (...)".
-         *
-         * Not a parser limitation: JSQLParser 4.9 parses "col = ANY (ARRAY['A','B'])" without
-         * complaint, as an EqualsTo whose right side is a Function named ANY. JSqlVisitor is what
-         * cannot handle it: visit(Function) only unwraps LOWER and UPPER, and throws for anything
-         * else. The rewrite lands the expression on InExpression instead, which it does support.
-         *
-         * TODO Upgrading JSQLParser has no effect on this rule. It can be dropped once
-         * visit(Function) unwraps ANY and visit(EqualsTo) folds a list right-hand side into an
-         * SqlInCondition.
-         */
-        transformedStr = transformedStr.replaceAll("=\\s*ANY\\s*\\(([^<]*)\\)", " IN ($1)");
-
-
-        /*
-         * The Postgres "ARRAY[...]" wrapper is dropped, leaving the bare element list. Used within
-         * an enumeration, the elements alone carry the whole meaning.
-         *
-         * The group excludes "]" so the match ends at the array's own closing bracket rather than
-         * at the last one anywhere in the string.
-         *
-         * Not a parser limitation either: JSQLParser 4.9 parses "x = ARRAY[1,2]" fine, as an
-         * EqualsTo whose right side is an ArrayConstructor. JSqlVisitor throws "not yet
-         * implemented" from visit(ArrayConstructor).
-         *
-         * TODO Upgrading JSQLParser has no effect here either. It can be dropped once
-         * visit(ArrayConstructor) pushes the element list, which is the same SqlConditionList that
-         * visit(ExpressionList) already builds for an IN.
-         */
-        transformedStr =  transformedStr.replaceAll("ARRAY\\s*\\[([^\\]]*)\\]", "$1");
 
         /*
          * MySQL Enum.

--- a/core-extra/dbconstraint/src/main/java/org/evomaster/dbconstraint/parser/jsql/JSqlVisitor.java
+++ b/core-extra/dbconstraint/src/main/java/org/evomaster/dbconstraint/parser/jsql/JSqlVisitor.java
@@ -36,6 +36,9 @@ public class JSqlVisitor implements ExpressionVisitor {
     private static final String LOWER = "LOWER";
     private static final String UPPER = "UPPER";
 
+    private static final String ANY = "ANY";
+    private static final String SOME = "SOME";
+
     private static final String SINGLE_QUOTE_CHAR = "'";
 
     /**
@@ -296,9 +299,57 @@ public class JSqlVisitor implements ExpressionVisitor {
     public void visit(EqualsTo equalsTo) {
         equalsTo.getLeftExpression().accept(this);
         SqlCondition left = stack.pop();
+
+        ArrayConstructor alternatives = membershipArrayOf(equalsTo.getRightExpression());
+        if (alternatives != null) {
+            /*
+             * "col = ANY (ARRAY['A','B'])" is a membership test, equivalent to
+             * "col IN ('A','B')", so it is translated to the node that already means that.
+             */
+            if (!(left instanceof SqlColumn)) {
+                throw new RuntimeException("Extraction of condition not yet implemented");
+            }
+            alternatives.accept(this);
+            SqlConditionList literals = (SqlConditionList) stack.pop();
+            stack.push(new SqlInCondition((SqlColumn) left, literals));
+            return;
+        }
+
         equalsTo.getRightExpression().accept(this);
         SqlCondition right = stack.pop();
+        if (right instanceof SqlConditionList) {
+            /*
+             * A bare "col = ARRAY[...]" compares a value against an array rather than testing
+             * membership in it, and there is no node for that. Reading it as an IN would answer a
+             * different question than the constraint asks, so it is left untranslated.
+             */
+            throw new RuntimeException("Extraction of condition not yet implemented");
+        }
         stack.push(new SqlComparisonCondition(left, SqlComparisonOperator.EQUALS_TO, right));
+    }
+
+    /**
+     * The array of alternatives in a membership test, or null if the expression is not one.
+     *
+     * <p>Only {@code ANY} and {@code SOME} qualify, and only over an array literal. {@code ALL}
+     * requires every element to match rather than one, and {@code ANY} over a subquery carries no
+     * literals to enumerate, so neither can be answered with an {@code IN}.
+     */
+    private static ArrayConstructor membershipArrayOf(Expression expression) {
+        if (!(expression instanceof Function)) {
+            return null;
+        }
+        Function function = (Function) expression;
+        String name = function.getName().toUpperCase();
+        if (!name.equals(ANY) && !name.equals(SOME)) {
+            return null;
+        }
+        ExpressionList<?> parameters = function.getParameters();
+        if (parameters == null || parameters.size() != 1
+                || !(parameters.get(0) instanceof ArrayConstructor)) {
+            return null;
+        }
+        return (ArrayConstructor) parameters.get(0);
     }
 
 
@@ -325,8 +376,22 @@ public class JSqlVisitor implements ExpressionVisitor {
         inExpression.getLeftExpression().accept(this);
         SqlColumn left = (SqlColumn) stack.pop();
         inExpression.getRightExpression().accept(this);
-        SqlConditionList right = (SqlConditionList) stack.pop();
+        SqlConditionList right = unwrapSingletonArray((SqlConditionList) stack.pop());
         stack.push(new SqlInCondition(left, right));
+    }
+
+    /**
+     * Flattens the one nested level that {@code IN (ARRAY[...])} produces.
+     *
+     * <p>The parenthesis around the array is itself an expression list, so the array's elements
+     * arrive wrapped in a list of one. The alternatives are the elements, not the array.
+     */
+    private static SqlConditionList unwrapSingletonArray(SqlConditionList list) {
+        List<SqlCondition> elements = list.getSqlConditionExpressions();
+        if (elements.size() == 1 && elements.get(0) instanceof SqlConditionList) {
+            return (SqlConditionList) elements.get(0);
+        }
+        return list;
     }
 
     @Override
@@ -717,10 +782,15 @@ public class JSqlVisitor implements ExpressionVisitor {
         throw new RuntimeException("Extraction of condition not yet implemented");
     }
 
+    /**
+     * An array literal, e.g. {@code ARRAY['A','B']}, becomes the list of its elements: the same
+     * {@link SqlConditionList} that {@link #visit(ExpressionList)} builds for the right-hand side of
+     * an {@code IN}. What that list means is decided by whoever consumes it, since an array is a
+     * value in its own right and only membership tests turn it into a set of alternatives.
+     */
     @Override
     public void visit(ArrayConstructor aThis) {
-        // TODO This translation should be implemented
-        throw new RuntimeException("Extraction of condition not yet implemented");
+        aThis.getExpressions().accept(this);
     }
 
     @Override

--- a/core-extra/dbconstraint/src/test/java/org/evomaster/dbconstraint/SqlConditionParserTest.java
+++ b/core-extra/dbconstraint/src/test/java/org/evomaster/dbconstraint/SqlConditionParserTest.java
@@ -356,6 +356,60 @@ class SqlConditionParserTest {
     }
 
     /**
+     * The shape PostgreSQL emits for an enumerated column, with the array wrapped in a cast. JSQLParser
+     * cannot read this one, so it is still rewritten before parsing.
+     */
+    @Test
+    void testEnumWithArrayCast() throws Exception {
+        assertEquals(in("c", "A", "B"),
+                parse("((c)::text = ANY ((ARRAY['A'::character varying, 'B'::character varying])::text[]))",
+                        ConstraintDatabaseType.POSTGRES));
+    }
+
+    /**
+     * The same shape cast to a type whose name is two words. PostgreSQL spells several of its types
+     * that way, "character varying" and "double precision" among them. A pattern matching a single
+     * word skips these constraints entirely: nothing is rewritten, JSQLParser then rejects the
+     * expression, and the constraint is discarded without any counter recording it.
+     */
+    @Test
+    void testEnumCastToAMultiWordType() throws Exception {
+        assertEquals(in("c", "A"),
+                parse("((c)::text = ANY ((ARRAY['A'::character varying])::character varying[]))",
+                        ConstraintDatabaseType.POSTGRES));
+        assertEquals(in("c", "A"),
+                parse("((c)::text = ANY ((ARRAY['A'::text])::double precision[]))",
+                        ConstraintDatabaseType.POSTGRES));
+    }
+
+    /**
+     * PostgreSQL also casts each element instead of the array. Nothing needs rewriting here, since
+     * JSQLParser reads it and the visitor drops the casts on its way to the literals.
+     */
+    @Test
+    void testEnumWithPerElementCasts() throws Exception {
+        assertEquals(in("c", "A", "B"),
+                parse("((c)::text = ANY (ARRAY[('A'::character varying)::text, ('B'::character varying)::text]))",
+                        ConstraintDatabaseType.POSTGRES));
+    }
+
+    /** A schema dump wraps long constraints, so the shape has to survive newlines inside it. */
+    @Test
+    void testEnumSpanningSeveralLines() throws Exception {
+        assertEquals(in("c", "A", "B"),
+                parse("((c)::text = ANY\n   ((ARRAY['A'::character varying,\n     'B'::character varying])::text[]))",
+                        ConstraintDatabaseType.POSTGRES));
+    }
+
+    /** The enum test is rarely alone in a CHECK, and rewriting it must not disturb its neighbours. */
+    @Test
+    void testEnumAlongsideAnotherCondition() throws Exception {
+        assertEquals(and(in("c", "A"), new SqlComparisonCondition(column("n"), SqlComparisonOperator.GREATER_THAN, intL(0))),
+                parse("((c)::text = ANY ((ARRAY['A'::character varying])::text[])) AND (n > 0)",
+                        ConstraintDatabaseType.POSTGRES));
+    }
+
+    /**
      * ALL requires every element to match rather than one, so it is not a membership test and must not
      * be folded into an IN. Left untranslated rather than answered with a different question.
      */

--- a/core-extra/dbconstraint/src/test/java/org/evomaster/dbconstraint/SqlConditionParserTest.java
+++ b/core-extra/dbconstraint/src/test/java/org/evomaster/dbconstraint/SqlConditionParserTest.java
@@ -53,6 +53,11 @@ class SqlConditionParserTest {
         return new SqlInCondition(column(columName), stringLiteralList);
     }
 
+    private static SqlInCondition inNumbers(String columName, int... values) {
+        List<SqlCondition> literals = Arrays.stream(values).mapToObj(SqlConditionParserTest::intL).collect(Collectors.toList());
+        return new SqlInCondition(column(columName), new SqlConditionList(literals));
+    }
+
     private static SqlCondition parse(String conditionSqlStr, ConstraintDatabaseType databaseType) throws SqlConditionParserException {
         JSqlConditionParser parser = new JSqlConditionParser();
         return parser.parse(conditionSqlStr, databaseType);
@@ -322,27 +327,63 @@ class SqlConditionParserTest {
     }
 
     /**
-     * PostgreSQL also emits the ANY/ARRAY pair without the array cast, and a bare ARRAY can appear on
-     * its own. Neither is covered by the rule that recognises the full enum shape, so the general
-     * ARRAY rule has to keep handling them.
+     * PostgreSQL also emits the ANY/ARRAY pair without the array cast. JSQLParser reads that spelling,
+     * so no rewriting happens and the shape reaches the visitor intact: "= ANY (ARRAY[...])" asks
+     * whether the column is one of the alternatives, which is what IN means.
      */
     @Test
-    void testArrayWithoutCastIsStillTransformed() throws Exception {
-        JSqlConditionParser parser = new JSqlConditionParser();
+    void testAnyOverArrayIsAMembershipTest() throws Exception {
+        assertEquals(in("c", "A", "B"),
+                parse("(c = ANY (ARRAY['A', 'B']))", ConstraintDatabaseType.POSTGRES));
+    }
 
-        assertNotNull(parser.parse("(c = ANY (ARRAY['A', 'B']))", ConstraintDatabaseType.POSTGRES));
+    /** SOME is a synonym of ANY, and has to translate the same way. */
+    @Test
+    void testSomeOverArrayIsAMembershipTest() throws Exception {
+        assertEquals(in("c", "A", "B"),
+                parse("(c = SOME (ARRAY['A', 'B']))", ConstraintDatabaseType.POSTGRES));
     }
 
     /**
-     * Two arrays in one expression. The rule used to exclude only '<' from its group, so the match ran
-     * from the first "ARRAY[" to the last "]" anywhere in the string and swallowed everything between
-     * them, producing "(a = 1,2] AND b = ARRAY[3,4)". Excluding ']' ends each match at its own array.
+     * Two arrays in one expression, each inside its own IN. The parenthesis around an array is itself
+     * an expression list, so the elements arrive one level deeper than for a plain IN; each array has
+     * to yield its own alternatives rather than a single nested value.
      */
     @Test
     void testTwoArraysInOneExpression() throws Exception {
-        JSqlConditionParser parser = new JSqlConditionParser();
+        assertEquals(and(inNumbers("a", 1, 2), inNumbers("b", 3, 4)),
+                parse("(a IN (ARRAY[1,2]) AND b IN (ARRAY[3,4]))", ConstraintDatabaseType.POSTGRES));
+    }
 
-        assertNotNull(parser.parse("(a IN (ARRAY[1,2]) AND b IN (ARRAY[3,4]))", ConstraintDatabaseType.POSTGRES));
+    /**
+     * ALL requires every element to match rather than one, so it is not a membership test and must not
+     * be folded into an IN. Left untranslated rather than answered with a different question.
+     */
+    @Test
+    void testAllOverArrayIsNotAMembershipTest() {
+        assertThrows(RuntimeException.class,
+                () -> parse("(c = ALL (ARRAY['A', 'B']))", ConstraintDatabaseType.POSTGRES));
+    }
+
+    /**
+     * A bare "c = ARRAY[...]" compares the column against an array value instead of testing
+     * membership in it. There is no node for that, and reading it as an IN would make the constraint
+     * mean something it does not say.
+     */
+    @Test
+    void testArrayEqualityIsNotAMembershipTest() {
+        assertThrows(RuntimeException.class,
+                () -> parse("c = ARRAY['A', 'B']", ConstraintDatabaseType.POSTGRES));
+    }
+
+    /**
+     * PostgreSQL can also spell an array as a string literal. Its elements are not visible as
+     * expressions, so there is nothing to enumerate and the condition is left untranslated.
+     */
+    @Test
+    void testAnyOverAStringLiteralIsNotTranslated() {
+        assertThrows(RuntimeException.class,
+                () -> parse("c = ANY ('{A,B}')", ConstraintDatabaseType.POSTGRES));
     }
 
     @Timeout(value = 10, unit = SECONDS)


### PR DESCRIPTION
## The finding

`transformDialect` rewrites dialect constructs before handing the expression to JSQLParser. Two of its rules carried comments blaming the parser:

> The JSQL parser does not properly parse the Postgresql SQL dialect function "ANY"

> The JSQL parser does not properly handle the Postgres "ARRAY[...]" construct

Neither is true of JSQLParser 4.9. Both constructs parse:

| Input | JSQLParser 4.9 | JSqlVisitor |
|---|---|---|
| `col = ANY (ARRAY['A','B'])` | `EqualsTo` over a `Function` named ANY | `visit(Function)` throws, it only unwraps LOWER and UPPER |
| `x = ARRAY[1,2]` | `EqualsTo` over an `ArrayConstructor` | `visit(ArrayConstructor)` throws |

The obstacle was on our side. Upgrading the parser would never have made those rules unnecessary.

## The change

`JSqlVisitor` learns the two nodes, so the constructs are translated from the AST, where the intent is explicit, instead of being guessed at from the text:

* `visit(ArrayConstructor)` pushes the element list: the same `SqlConditionList` that `visit(ExpressionList)` already builds for an `IN`.
* `visit(EqualsTo)` folds `= ANY (ARRAY[...])` and `= SOME (ARRAY[...])` into an `SqlInCondition`. Both are membership tests, which is what `IN` means.
* `visit(InExpression)` unwraps the extra level that `IN (ARRAY[...])` produces, since the parenthesis around an array is itself an expression list.

With those in place the two regex rules are dead, and are removed. `transformDialect` goes from five rules to three, and every rule left is a real parser limitation.

## A bug the removal exposed

The rule that recognises the full enum shape matched the cast target as `\w+`, so it only ever fired on a single-word type. PostgreSQL spells several of its types with a space, `character varying` and `double precision` among them, and for those the rule did not fire at all.

That went unnoticed because the two general rules picked up the slack. With them gone the constraint was silently discarded instead, so the cast target is now matched as a sequence of words. `testEnumCastToAMultiWordType` is the guard: it fails on the old pattern and passes on this one.

## Behaviour compared against the base branch

Sixteen real constraint shapes, run through both versions:

| | Result |
|---|---|
| enum with array cast, single and multi word, per-element casts, spanning lines, next to another condition | unchanged |
| `= ANY (ARRAY[...])`, `= SOME (ARRAY[...])`, `IN (ARRAY[...])` | unchanged |
| MySQL enum, H2 `CHARACTER LARGE OBJECT`, plain `IN`, plain `=` | unchanged |
| `c = ANY ('{A,B}')` | **changed on purpose**, see below |

One shape changes. The regex turned `c = ANY ('{A,B}')` into `c IN ('{A,B}')`, a single element `IN` meaning the column equals the literal string `{A,B}`, and that wrong condition was applied with no counter recording it. The elements sit inside a string literal, so there is nothing to enumerate, and it is now left untranslated. Dropping a constraint weakens the formula, which is the accepted failure mode; applying a wrong one is not.

## What is deliberately not translated

| Input | Why |
|---|---|
| `c = ALL (ARRAY[...])` | ALL requires every element to match, not one, so it is not a membership test |
| `c = ARRAY['A','B']` | compares against an array value; reading it as `IN` would answer a different question than the constraint asks |
| `c = ANY ('{A,B}')` | the elements sit inside a string literal, so there is nothing to enumerate |
| `c = ANY (SELECT ...)` | no literals to enumerate; it already ended up dropped before, via `ParenthesedSelect` |

None of these is a regression: all four already failed, three by throwing and one by producing a wrong condition.

## Tests

The two existing array tests guarded the regex and asserted only `assertNotNull`, which did not check the translation at all. They now assert the resulting tree and exercise the visitor path.

Ten cases added, covering every shape in the table above: the five PostgreSQL enum spellings, `SOME`, `ALL`, bare array equality, the string literal array, and the two-array shape.

`mvn test -pl core-extra/dbconstraint`: 65 tests, 0 failures.
