### PR TITLE
AsyncAPI 3.x: run the parser against real published documents

### DIFF
--- a/core-extra/asyncapi-parser/src/test/java/com/webfuzzing/asyncapi/AsyncApiCorpusSweepMain.java
+++ b/core-extra/asyncapi-parser/src/test/java/com/webfuzzing/asyncapi/AsyncApiCorpusSweepMain.java
@@ -1,0 +1,156 @@
+package com.webfuzzing.asyncapi;
+
+import com.webfuzzing.asyncapi.access.AsyncApiAccess;
+import com.webfuzzing.asyncapi.models.AsyncApiDocument;
+import com.webfuzzing.asyncapi.models.AsyncApiOperation;
+import com.webfuzzing.asyncapi.models.AsyncApiServer;
+import com.webfuzzing.asyncapi.parser.AsyncApiParsingException;
+
+import java.io.File;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+
+/**
+ * Parses every AsyncAPI document in a folder tree and prints what came out of each.
+ *
+ * This is a research aid rather than a test: it is meant to be pointed at a local corpus of
+ * real documents, far too large to check into a repository. It is how a change to the parser is
+ * checked against every document at once -- what still parses, how many operations were found,
+ * and what had to be skipped.
+ *
+ * Usage: pass the folder to sweep as the first argument.
+ */
+public class AsyncApiCorpusSweepMain {
+
+    private AsyncApiCorpusSweepMain() {
+    }
+
+    public static void main(String[] args) {
+
+        File root = new File(args.length > 0 ? args[0] : defaultFolder());
+
+        if (!root.exists()) {
+            System.out.println("Usage: AsyncApiCorpusSweepMain <folder of AsyncAPI documents>");
+            System.out.println("No such folder: " + root.getAbsolutePath());
+            return;
+        }
+
+        List<File> documents = new ArrayList<>();
+        collectDocuments(root, documents);
+        Collections.sort(documents, Comparator.comparing(File::getPath));
+
+        int parsed = 0;
+        int rejected = 0;
+        int withWarnings = 0;
+
+        for (File file : documents) {
+
+            String label = file.getAbsolutePath().substring(root.getAbsolutePath().length() + 1);
+
+            try {
+                AsyncApiDocument document = AsyncApiAccess.getAsyncApiFromLocation(file.getAbsolutePath());
+
+                parsed++;
+
+                int driveable = 0;
+                int withReply = 0;
+
+                for (AsyncApiOperation operation : document.getOperations().values()) {
+                    if (operation.getAction() == AsyncApiOperation.Action.RECEIVE
+                            && !operation.getMessageIds().isEmpty()) {
+                        driveable++;
+                    }
+                    if (operation.getReply() != null) {
+                        withReply++;
+                    }
+                }
+
+                System.out.println(
+                        "OK    " + label
+                                + " | v" + document.getVersion()
+                                + " | " + document.getOperations().size() + " ops"
+                                + " (" + driveable + " consumed, " + withReply + " with reply)"
+                                + " | " + document.getChannels().size() + " channels"
+                                + " | " + document.getMessages().size() + " messages"
+                                + " | " + protocolsOf(document));
+
+                if (!document.getWarnings().isEmpty()) {
+                    withWarnings++;
+                    for (String warning : document.getWarnings()) {
+                        System.out.println("        ! " + warning);
+                    }
+                }
+
+            } catch (AsyncApiParsingException e) {
+                rejected++;
+                System.out.println("SKIP  " + label + " | " + e.getMessage());
+            } catch (Exception e) {
+                rejected++;
+                System.out.println(
+                        "FAIL  " + label + " | " + e.getClass().getSimpleName() + ": " + e.getMessage());
+            }
+        }
+
+        System.out.println();
+        System.out.println(
+                documents.size() + " documents: " + parsed + " parsed (" + withWarnings
+                        + " with warnings), " + rejected + " not parsed");
+    }
+
+    private static String protocolsOf(AsyncApiDocument document) {
+
+        if (document.getServers().isEmpty()) {
+            return "no server";
+        }
+
+        StringBuilder protocols = new StringBuilder();
+
+        for (AsyncApiServer server : document.getServers().values()) {
+            if (protocols.length() > 0) {
+                protocols.append(",");
+            }
+            protocols.append(server.getProtocol());
+        }
+
+        return protocols.toString();
+    }
+
+    private static void collectDocuments(File folder, List<File> found) {
+
+        File[] entries = folder.listFiles();
+
+        if (entries == null) {
+            return;
+        }
+
+        for (File entry : entries) {
+            if (entry.isDirectory()) {
+                collectDocuments(entry, found);
+            } else if (entry.getName().endsWith(".yaml") || entry.getName().endsWith(".yml")) {
+                found.add(entry);
+            }
+        }
+    }
+
+    /**
+     * The documents that ship with the tests, so that this runs for anybody who checks the
+     * repository out rather than only where a research corpus happens to live.
+     */
+    private static String defaultFolder() {
+
+        URL resource = AsyncApiCorpusSweepMain.class.getResource("/asyncapi");
+
+        if (resource == null) {
+            return ".";
+        }
+
+        try {
+            return new File(resource.toURI()).getAbsolutePath();
+        } catch (Exception e) {
+            return ".";
+        }
+    }
+}

--- a/core-extra/asyncapi-parser/src/test/java/com/webfuzzing/asyncapi/AsyncApiParserTest.java
+++ b/core-extra/asyncapi-parser/src/test/java/com/webfuzzing/asyncapi/AsyncApiParserTest.java
@@ -1265,4 +1265,213 @@ public class AsyncApiParserTest {
         assertTrue(warns(document, "nothing", "host and protocol"), document.getWarnings().toString());
     }
 
+    // ------------------------------------------------------------------ real documents
+
+    /*
+        Everything above is written to pin down one thing at a time. What follows runs the
+        parser against documents taken as published from real services, because the shapes that
+        actually break a parser are not the ones you think to write yourself: a channel with no
+        address whose topic hides in a binding, a reply whose address is announced inside the
+        request, a document with four servers and no way to tell which is meant.
+     */
+
+    private AsyncApiDocument loadSut(String name) {
+        return AsyncApiAccess.getAsyncApiFromResource("/asyncapi/sut/" + name);
+    }
+
+    @Test
+    public void testNcsOverKafka() {
+
+        AsyncApiDocument document = loadSut("ncs-kafka.yaml");
+
+        assertTrue(document.getWarnings().isEmpty(), "unexpected warnings: " + document.getWarnings());
+        assertEquals(12, document.getChannels().size());
+        assertEquals(6, document.getOperations().size());
+        assertEquals(9, document.getComponentSchemas().size());
+
+        //every operation is one the service consumes, and every one of them answers
+        for (AsyncApiOperation operation : document.getOperations().values()) {
+            assertEquals(AsyncApiOperation.Action.RECEIVE, operation.getAction(), operation.getName());
+            assertNotNull(operation.getReply(), operation.getName());
+        }
+
+        AsyncApiOperation bessj = document.getOperations().get("bessj");
+        assertEquals("bessjRequest", bessj.getChannelName());
+        assertEquals(Arrays.asList("bessjRequest"), bessj.getMessageIds());
+        assertEquals("bessjReply", bessj.getReply().getChannelName());
+        //two declared outcomes: a result and an error, which is what a search can tell apart
+        assertEquals(Arrays.asList("doubleResult", "error"), bessj.getReply().getMessageIds());
+
+        //an operation whose contract declares a single outcome, for contrast
+        assertEquals(
+                Arrays.asList("intResult"),
+                document.getOperations().get("checkTriangle").getReply().getMessageIds());
+
+        assertEquals("ncs.bessj.request", document.getChannels().get("bessjRequest").getAddress());
+        assertEquals("kafka", document.getServers().get("kafka").getProtocol());
+    }
+
+    @Test
+    public void testNcsPayloadsAndCorrelation() {
+
+        AsyncApiDocument document = loadSut("ncs-kafka.yaml");
+
+        AsyncApiMessage request = document.getMessages().get("bessjRequest");
+        assertEquals("application/json", request.getContentType());
+
+        //the payload keeps its reference, and what it points at is available
+        assertEquals("#/components/schemas/BessjRequest", request.getPayload().get("$ref").asText());
+        assertEquals(3, document.getComponentSchemas().get("BessjRequest")
+                .get("properties").get("n").get("minimum").asInt());
+
+        AsyncApiCorrelationId correlation = request.getCorrelationId();
+        assertEquals(AsyncApiCorrelationId.Source.HEADER, correlation.getSource());
+        assertEquals("correlationId", correlation.getFieldName());
+    }
+
+    @Test
+    public void testNcsOverAmqpDiffersOnlyInBindings() {
+
+        AsyncApiDocument kafka = loadSut("ncs-kafka.yaml");
+        AsyncApiDocument amqp = loadSut("ncs-amqp.yaml");
+
+        //the same interactions and the same message shapes, over a different transport
+        assertEquals(kafka.getOperations().keySet(), amqp.getOperations().keySet());
+        assertEquals(kafka.getChannels().keySet(), amqp.getChannels().keySet());
+        assertEquals(kafka.getMessages().keySet(), amqp.getMessages().keySet());
+        assertEquals(kafka.getComponentSchemas().keySet(), amqp.getComponentSchemas().keySet());
+
+        assertEquals("amqp", amqp.getServers().get("rabbitmq").getProtocol());
+        assertEquals("queue", amqp.getChannels().get("bessjRequest").getBindings().getAmqpIs());
+        assertNull(kafka.getChannels().get("bessjRequest").getBindings().getAmqpIs());
+    }
+
+    @Test
+    public void testAChannelWhoseTopicOnlyExistsInItsBinding() {
+
+        AsyncApiDocument document = loadSut("microcks.yaml");
+
+        AsyncApiChannel channel = document.getChannels().get("service-changes");
+
+        //this channel declares no address at all: the Kafka binding carries the topic
+        assertNull(channel.getAddress());
+        assertEquals("microcks-services-updates", channel.effectiveAddress("kafka"));
+        //the same document also declares a WebSocket binding, where the topic means nothing
+        assertEquals("POST", channel.getBindings().getWsMethod());
+        assertNull(channel.effectiveAddress("ws"));
+    }
+
+    @Test
+    public void testAChannelAddingAKeyToASharedMessage() {
+
+        AsyncApiDocument document = loadSut("microcks.yaml");
+
+        AsyncApiOperation operation = document.getOperations().get("receivedServiceChanges");
+        assertEquals(AsyncApiOperation.Action.RECEIVE, operation.getAction());
+
+        /*
+            The channel adds a Kafka key on top of the shared definition, which makes it a
+            variant belonging to this channel. The shared definition must be left alone, or
+            every other channel carrying the same message would inherit a key meant for this
+            one.
+         */
+        assertEquals(Arrays.asList("service-changes.serviceChangeEvent"), operation.getMessageIds());
+
+        AsyncApiMessage variant = document.getMessages().get("service-changes.serviceChangeEvent");
+        assertEquals("string", variant.getKafkaKey().get("type").asText());
+        assertNotNull(variant.getPayload());
+
+        assertNull(document.getMessages().get("serviceChangeEvent").getKafkaKey());
+    }
+
+    @Test
+    public void testAReplyAddressAnnouncedInTheRequest() {
+
+        AsyncApiDocument document = loadSut("everest.yaml");
+
+        assertEquals(8, document.getOperations().size());
+
+        AsyncApiReply reply = document.getOperations().get("send_request_get_errors").getReply();
+
+        assertEquals("receive_reply_get_errors", reply.getChannelName());
+        //the reply channel has no address of its own: the requester picks one per request
+        assertNull(document.getChannels().get("receive_reply_get_errors").getAddress());
+        assertEquals("$message.header#/replyTo", reply.getAddressLocation());
+    }
+
+    @Test
+    public void testAServerWhosePathIsTemplated() {
+
+        AsyncApiServer server = loadSut("everest.yaml").getServers().get("default");
+
+        assertEquals("mqtt", server.getProtocol());
+        assertEquals("localhost:1883", server.getHost());
+        assertEquals("everest_api/1/error_history_consumer/{module_id}", server.getPathname());
+        assertEquals(
+                "The ID of the module as defined in the EVerest config file.",
+                server.getVariables().get("module_id").getDescription());
+    }
+
+    @Test
+    public void testFourServersAndAContentTypeOfItsOwn() {
+
+        AsyncApiDocument document = loadSut("bookworm-rating.yaml");
+
+        assertEquals("application/vnd.masstransit+json", document.getDefaultContentType());
+        assertEquals(4, document.getServers().size());
+
+        AsyncApiServer development = document.getServers().get("development");
+        assertEquals("amqp", development.getProtocol());
+        assertEquals("0.9.1", development.getProtocolVersion());
+
+        //the scheme is written inline on the server rather than declared in components
+        assertEquals(1, development.getSecurity().size());
+        assertEquals(
+                "userpassword",
+                document.getSecuritySchemes().get(development.getSecurity().get(0)).getType());
+
+        //messages inherit the document's content type when they declare none
+        for (AsyncApiMessage message : document.getMessages().values()) {
+            assertEquals("application/vnd.masstransit+json", message.getContentType(), message.getId());
+        }
+    }
+
+    @Test
+    public void testRequestAndResponseModelledAsSeparateOperations() {
+
+        AsyncApiDocument document = loadSut("openagents-cache.yaml");
+
+        assertEquals(11, document.getOperations().size());
+
+        int send = 0;
+        int receive = 0;
+
+        for (AsyncApiOperation operation : document.getOperations().values()) {
+            //no operation declares a reply: request and response are separate channels here,
+            //which is exactly the shape a black-box tester cannot pair up on its own
+            assertNull(operation.getReply(), operation.getName());
+            if (operation.getAction() == AsyncApiOperation.Action.SEND) {
+                send++;
+            } else {
+                receive++;
+            }
+        }
+
+        /*
+            Note the polarity. This document is written from the point of view of the agent
+            *using* the cache, so issuing a request is 'send' and the answer is 'receive'. The
+            parser reports what the document says and nothing more: which end is the system
+            under test is not something the document settles.
+         */
+        assertEquals(
+                AsyncApiOperation.Action.SEND,
+                document.getOperations().get("createCache").getAction());
+        assertEquals(
+                AsyncApiOperation.Action.RECEIVE,
+                document.getOperations().get("receiveCacheCreateResponse").getAction());
+        assertEquals(4, send);
+        assertEquals(7, receive);
+
+        assertEquals("shared_cache.create", document.getChannels().get("cacheCreate").getAddress());
+    }
 }

--- a/core-extra/asyncapi-parser/src/test/resources/asyncapi/sut/bookworm-rating.yaml
+++ b/core-extra/asyncapi-parser/src/test/resources/asyncapi/sut/bookworm-rating.yaml
@@ -1,0 +1,222 @@
+# Source: https://github.com/foxminchan/BookWorm (MIT), unmodified.
+---
+asyncapi: 3.0.0
+info:
+  title: Rating Service API
+  version: 1.0.0
+  description: Handles the collection, storage, and aggregation of user feedback and
+    ratings for books on the BookWorm platform
+  contact:
+    name: Nhan Nguyen
+    url: "https://github.com/foxminchan"
+  license:
+    name: MIT
+    url: "https://opensource.org/licenses/MIT"
+defaultContentType: application/vnd.masstransit+json
+servers:
+  development:
+    host: dev.eventbus:5672
+    protocol: amqp
+    protocolVersion: 0.9.1
+    summary: RabbitMQ server for development environment
+    description: RabbitMQ server for development environment
+    security:
+      - type: userPassword
+        description: An authentication method for the server
+    tags:
+      - name: env:development
+        description: >-
+          Development environment configuration for local testing and debugging
+  staging:
+    host: stg.eventbus:5672
+    protocol: amqp
+    protocolVersion: 0.9.1
+    summary: RabbitMQ server for staging environment
+    description: RabbitMQ server for staging environment
+    security:
+      - type: userPassword
+        description: An authentication method for the server
+    tags:
+      - name: env:staging
+        description: >-
+          Staging environment configuration for testing and debugging
+  qa:
+    host: qa.eventbus:5672
+    protocol: amqp
+    protocolVersion: 0.9.1
+    summary: RabbitMQ server for QA environment
+    description: RabbitMQ server for QA environment
+    security:
+      - type: userPassword
+        description: An authentication method for the server
+    tags:
+      - name: env:qa
+        description: >-
+          QA environment configuration for testing and debugging
+  production:
+    host: prod.eventbus:5672
+    protocol: amqp
+    protocolVersion: 0.9.1
+    summary: RabbitMQ server for production environment
+    description: RabbitMQ server for production environment
+    security:
+      - type: userPassword
+        description: An authentication method for the server
+    tags:
+      - name: env:production
+        description: >-
+          Production environment configuration for production
+channels:
+  rating-book-updated-rating-failed:
+    address: rating-book-updated-rating-failed
+    description: Emit message when book rating update failed
+    messages:
+      BookUpdatedRatingFailedIntegrationEvent.message:
+        $ref: "#/components/messages/bookUpdatedRatingFailedIntegrationEvent"
+  catalog-feedback-created:
+    address: catalog-feedback-created
+    description: Emit message when feedback is created
+    messages:
+      FeedbackCreatedEvent.message:
+        $ref: "#/components/messages/feedbackCreatedEvent"
+  catalog-feedback-deleted:
+    address: catalog-feedback-deleted
+    description: Emit message when feedback is deleted
+    messages:
+      FeedbackDeletedEvent.message:
+        $ref: "#/components/messages/feedbackDeletedEvent"
+operations:
+  BookUpdatedRatingFailedIntegrationEvent:
+    title: Book updated rating failed
+    summary: Book updated rating failed
+    description: Represents a successful integration event when a book rating update fails
+    action: receive
+    channel:
+      $ref: "#/channels/rating-book-updated-rating-failed"
+    messages:
+      - $ref: >-
+          #/channels/rating-book-updated-rating-failed/messages/BookUpdatedRatingFailedIntegrationEvent.message
+  FeedbackCreatedEvent:
+    title: Feedback created
+    summary: Feedback created
+    description: Represents a successful integration event when a feedback is created
+    action: send
+    channel:
+      $ref: "#/channels/catalog-feedback-created"
+    messages:
+      - $ref: >-
+          #/channels/catalog-feedback-created/messages/FeedbackCreatedEvent.message
+  FeedbackDeletedEvent:
+    title: Feedback deleted
+    summary: Feedback deleted
+    description: Represents a successful integration event when a feedback is deleted
+    action: send
+    channel:
+      $ref: "#/channels/catalog-feedback-deleted"
+    messages:
+      - $ref: >-
+          #/channels/catalog-feedback-deleted/messages/FeedbackDeletedEvent.message
+components:
+  schemas:
+    bookUpdatedRatingFailedIntegrationEvent:
+      id: bookUpdatedRatingFailedIntegrationEvent
+      description: Represents a successful integration event when a book rating update fails
+      allOf:
+        - $ref: "#/components/schemas/integrationEvent"
+        - type: object
+          additionalProperties: false
+          properties:
+            feedbackId:
+              type: string
+              format: guid
+              description: The unique identifier of the feedback
+              example: "01961eb4-668d-7e7e-ae25-0fab379614f7"
+    integrationEvent:
+      id: integrationEvent
+      type: object
+      description: Base event structure containing common metadata for all integration events in the system
+      additionalProperties: false
+      properties:
+        id:
+          type: string
+          format: guid
+          description: The unique identifier of the integration event
+          example: "01961eb4-668d-7e7e-ae25-0fab379614f7"
+        creationDate:
+          type: string
+          format: date-time
+          description: The creation date of the integration event
+          example: "2021-01-01T00:00:00Z"
+    feedbackCreatedEvent:
+      id: feedbackCreatedEvent
+      description: Represents a successful integration event when a feedback is created
+      allOf:
+        - $ref: "#/components/schemas/domainEvent"
+        - type: object
+          additionalProperties: false
+          properties:
+            bookId:
+              type: string
+              format: guid
+              description: The unique identifier of the book
+              example: "01961eb4-668d-7e7e-ae25-0fab379614f7"
+            rating:
+              type: integer
+              format: int32
+              description: The rating of the feedback
+              example: 5
+              minimum: 1
+              maximum: 5
+            feedbackId:
+              type: string
+              format: guid
+              description: The unique identifier of the feedback
+              example: "01961eb4-668d-7e7e-ae25-0fab379614f7"
+    domainEvent:
+      id: domainEvent
+      description: Base event structure containing common metadata for all domain events in the system
+      type: object
+      x-abstract: true
+      additionalProperties: false
+      properties:
+        dateOccurred:
+          type: string
+          format: date-time
+    feedbackDeletedEvent:
+      id: feedbackDeletedEvent
+      description: Represents a successful integration event when a feedback is deleted
+      allOf:
+        - $ref: "#/components/schemas/domainEvent"
+        - type: object
+          additionalProperties: false
+          properties:
+            bookId:
+              type: string
+              format: guid
+              description: The unique identifier of the book
+              example: "01961eb4-668d-7e7e-ae25-0fab379614f7"
+            rating:
+              type: integer
+              format: int32
+              description: The rating of the feedback
+              example: 5
+              minimum: 1
+              maximum: 5
+            feedbackId:
+              type: string
+              format: guid
+              description: The unique identifier of the feedback
+              example: "01961eb4-668d-7e7e-ae25-0fab379614f7"
+  messages:
+    bookUpdatedRatingFailedIntegrationEvent:
+      payload:
+        $ref: "#/components/schemas/bookUpdatedRatingFailedIntegrationEvent"
+      name: bookUpdatedRatingFailedIntegrationEvent
+    feedbackCreatedEvent:
+      payload:
+        $ref: "#/components/schemas/feedbackCreatedEvent"
+      name: feedbackCreatedEvent
+    feedbackDeletedEvent:
+      payload:
+        $ref: "#/components/schemas/feedbackDeletedEvent"
+      name: feedbackDeletedEvent

--- a/core-extra/asyncapi-parser/src/test/resources/asyncapi/sut/everest.yaml
+++ b/core-extra/asyncapi-parser/src/test/resources/asyncapi/sut/everest.yaml
@@ -1,0 +1,349 @@
+# Source: https://github.com/EVerest/EVerest (Apache-2.0), unmodified extract.
+---
+asyncapi: 3.0.0
+id: 'pionix:de:everest:error_history_consumer_API'
+info:
+  title: 'EVerest API definition for error history (consumer)'
+  version: 1.0.0
+  description: >-
+    API for EVerest API clients for error status and history.
+
+  license:
+    name: Apache-2.0
+    url: https://opensource.org/licenses/Apache-2.0
+  tags:
+    - name: EVerest
+    - name: ErrorHistory
+servers:
+  default:
+    pathname: 'everest_api/1/error_history_consumer/{module_id}'
+    host: 'localhost:1883'
+    description: default local MQTT
+    protocol: mqtt
+    variables:
+      module_id:
+        description: The ID of the module as defined in the EVerest config file.
+defaultContentType: application/json
+
+
+channels:
+  send_request_get_errors:
+    address: 'm2e/get_errors'
+    messages:
+      send_request_get_errors:
+        $ref: '#/components/messages/send_request_get_errors'
+  receive_reply_get_errors:
+    address: null
+    messages:
+      receive_reply_get_errors:
+        $ref: '#/components/messages/receive_reply_get_errors'
+  send_request_active_errors:
+    address: 'm2e/active_errors'
+    messages:
+      send_request_active_errors:
+        $ref: '#/components/messages/send_request_active_errors'
+  receive_reply_active_errors:
+    address: null
+    messages:
+      receive_reply_active_errors:
+        $ref: '#/components/messages/receive_reply_active_errors'
+  receive_error_raised:
+    address: 'e2m/error_raised'
+    messages:
+      receive_error_raised:
+        $ref: '#/components/messages/receive_error_raised'
+  receive_error_cleared:
+    address: 'e2m/error_cleared'
+    messages:
+      receive_error_cleared:
+        $ref: '#/components/messages/receive_error_cleared'
+
+
+  receive_heartbeat:
+    address: 'e2m/heartbeat'
+    messages:
+      receive_heartbeat:
+        $ref: '#/components/messages/receive_heartbeat'
+  send_communication_check:
+    address: 'm2e/communication_check'
+    messages:
+      send_communication_check:
+        $ref: '#/components/messages/send_communication_check'
+
+
+
+operations:
+  send_request_get_errors:
+    title: 'Send request with a list of filters to get a list of filtered errors'
+    action: send
+    channel:
+      $ref: '#/channels/send_request_get_errors'
+    description: 'Direction: Module to EVerest'
+    reply:
+      address:
+        location: "$message.header#/replyTo"
+      channel:
+        $ref: '#/channels/receive_reply_get_errors'
+  receive_reply_get_errors:
+    title: 'Receive reply with a list of filtered errors'
+    action: receive
+    description: 'Direction: EVerest to Module'
+    channel:
+      $ref: '#/channels/receive_reply_get_errors'
+  send_request_active_errors:
+    title: 'Send request to transmit the list of currently active errors'
+    action: send
+    channel:
+      $ref: '#/channels/send_request_active_errors'
+    description: 'Direction: Module to EVerest'
+    reply:
+      address:
+        location: "$message.header#/replyTo"
+      channel:
+        $ref: '#/channels/receive_reply_active_errors'
+  receive_reply_active_errors:
+    title: 'Receive reply to transmit the list of currently active errors'
+    action: receive
+    description: 'Direction: EVerest to Module'
+    channel:
+      $ref: '#/channels/receive_reply_active_errors'
+  receive_error_raised:
+    title: 'Receive newly raised error'
+    action: receive
+    channel:
+      $ref: '#/channels/receive_error_raised'
+  receive_error_cleared:
+    title: 'Receive newly cleared error'
+    action: receive
+    channel:
+      $ref: '#/channels/receive_error_cleared'
+
+
+  receive_heartbeat:
+    title: 'Receive heartbeat'
+    action: receive
+    channel:
+      $ref: '#/channels/receive_heartbeat'
+  send_communication_check:
+    title: 'Send communication check'
+    action: send
+    channel:
+      $ref: '#/channels/send_communication_check'
+
+
+
+components:
+  messages:
+    send_request_get_errors:
+      name: send_request_get_errors
+      title: 'Request the list of filtered errors'
+      summary: 'Request the list of filtered errors.'
+      payload:
+        type: object
+        required:
+          - payload
+        properties:
+          headers:
+            type: object
+            properties:
+              replyTo:  # Address for the request to reply to
+                type: string
+                description: Address to send the response to.
+          payload:
+            $ref: '#/components/schemas/FilterArguments'
+    receive_reply_get_errors:
+      name: receive_reply_get_errors
+      title: 'List of filtered errors'
+      summary: 'Reply to the request to send the list of filtered errors'
+      contentType: application/json
+      payload:
+        $ref: '#/components/schemas/ErrorList'
+    send_request_active_errors:
+      name: send_request_active_errors
+      title: 'Request the list of active errors'
+      summary: 'Request the list of active errors.'
+      payload:
+        type: object
+        properties:
+          headers:
+            type: object
+            properties:
+              replyTo:  # Address for the request to reply to
+                type: string
+                description: Address to send the response to.
+      examples:
+        - summary: "Request active errors"
+          payload:
+            headers:
+              replyTo: everest_api/1/{interface_type}/{module_id}/e2m/{operation_name}/{uuid}
+    receive_reply_active_errors:
+      name: receive_reply_active_errors
+      title: 'The list of active errors'
+      summary: 'Reply to the request to send the list of active errors'
+      contentType: application/json
+      payload:
+        $ref: '#/components/schemas/ErrorList'
+    receive_error_raised:
+      name: receive_error_raised
+      title: 'Receive newly raised error'
+      summary: 'Notifies on every raised error'
+      contentType: application/json
+      payload:
+        $ref: '#/components/schemas/ErrorObject'
+    receive_error_cleared:
+      name: receive_error_cleared
+      title: 'Receive cleared error'
+      summary: 'Notifies when an error is cleared'
+      contentType: application/json
+      payload:
+        $ref: '#/components/schemas/ErrorObject'
+
+
+    receive_heartbeat:
+      name: receive_heartbeat
+      title: 'Receive heartbeat'
+      summary: Heartbeat produced by EVerest as configured via cfg_heartbeat_interval_ms in the EVerest configuration
+      contentType: application/json
+      payload:
+        $ref: '#/components/schemas/HeartBeatId'
+      examples:
+        - summary: "Heartbeat"
+          payload: 42
+
+    send_communication_check:
+      name: send_communication_check
+      title: 'Send communication check'
+      summary: Signal to EVerest that communication is good or check shall be stopped
+      contentType: application/json
+      payload:
+        $ref: '#/components/schemas/CommunicationCheck'
+      examples:
+        - summary: "CommunicationCheck"
+          payload:
+            true
+
+
+  schemas:
+    ErrorList:
+      description: A list of ErrorObjects
+      type: object
+      additionalProperties: true
+      required:
+        - errors
+      properties:
+        errors:
+          type: array
+          items:
+            $ref: '#/components/schemas/ErrorObject'
+    ErrorObject:
+      description: Represents an error
+      type: object
+      additionalProperties: true
+      required:
+        - type
+        - description
+        - message
+        - origin
+        - timestamp
+        - uuid
+        - severity
+        - state
+      properties:
+        type:
+          type: string
+          minLength: 2
+        sub_type:
+          type: string
+        description:
+          type: string
+          minLength: 2
+        message:
+          type: string
+          minLength: 2
+        severity:
+          $ref: '#/components/schemas/Severity'
+        origin:
+          $ref: '#/components/schemas/ImplementationIdentifier'
+        timestamp:
+          type: string
+          format: date-time
+        uuid:
+          type: string
+          minLength: 2
+        state:
+          $ref: '#/components/schemas/State'
+    FilterArguments:
+      description: Arguments for the get_errors command
+      type: object
+      additionalProperties: true
+      required: []
+      properties:
+        state_filter:
+          $ref: '#/components/schemas/State'
+        origin_filter:
+          $ref: '#/components/schemas/ImplementationIdentifier'
+        type_filter:
+          type: string
+        severity_filter:
+          $ref: '#/components/schemas/SeverityFilter'
+        timeperiod_filter:
+          $ref: '#/components/schemas/TimeperiodFilter'
+        handle_filter:
+          type: string
+          description: Handle of an error
+    ImplementationIdentifier:
+      description: Identifier of an implementation
+      type: object
+      additionalProperties: true
+      required:
+        - module_id
+        - implementation_id
+      properties:
+        module_id:
+          type: string
+          minLength: 2
+        implementation_id:
+          type: string
+          minLength: 2
+    Severity:
+      description: Severity of an error
+      type: string
+      enum:
+        - High
+        - Medium
+        - Low
+    SeverityFilter:
+      description: Severity filter for errors
+      type: string
+      enum:
+        - HIGH_GE
+        - MEDIUM_GE
+        - LOW_GE
+    State:
+      description: State of an error
+      type: string
+      enum:
+        - Active
+        - ClearedByModule
+        - ClearedByReboot
+    TimeperiodFilter:
+      description: Timeperiod filter for errors
+      type: object
+      additionalProperties: true
+      required:
+        - timestamp_from
+        - timestamp_to
+      properties:
+        timestamp_from:
+          type: string
+          format: date-time
+        timestamp_to:
+          type: string
+          format: date-time
+
+    CommunicationCheck:
+      type: boolean
+      description: "Send 'true' at least every 'cfg_communication_check_to_s' seconds to signal module is alive. Send 'false' to stop communication check'"
+    HeartBeatId:
+      type: integer
+      description: "64bit unsigned integer. The id of every heartbeat increases by 1 and overflows when the maximum representable value is reached"

--- a/core-extra/asyncapi-parser/src/test/resources/asyncapi/sut/microcks.yaml
+++ b/core-extra/asyncapi-parser/src/test/resources/asyncapi/sut/microcks.yaml
@@ -1,0 +1,418 @@
+# Source: https://github.com/microcks/microcks (Apache-2.0), unmodified.
+asyncapi: 3.0.0
+info:
+  title: Microcks Events API v1.10
+  version: 1.10.1
+  description: "Events API offered by Microcks, the Kubernetes native tool for API and microservices\
+    \ mocking and testing (microcks.io)"
+  contact:
+    name: Laurent Broudoux
+    url: https://github.com/microcks
+    email: laurent@microcks.io
+  license:
+    name: Apache 2.0
+    url: https://www.apache.org/licenses/LICENSE-2.0
+  x-logo:
+    backgroundColor: '#ffffff'
+    url: https://microcks.io/images/microcks-logo-blue.png
+defaultContentType: application/json
+channels:
+  service-changes:
+    description: A channel where Services changes are published
+    messages:
+      serviceChangeEvent:
+        $ref: '#/components/messages/serviceChangeEvent'
+        bindings:
+          kafka:
+            key:
+              type: string
+    bindings:
+      ws:
+        method: POST
+      kafka:
+        topic: 'microcks-services-updates'
+operations:
+  receivedServiceChanges:
+    action: receive
+    channel:
+      $ref: '#/channels/service-changes'
+    summary: Receive information about Service changes
+    messages:
+      - $ref: '#/channels/service-changes/messages/serviceChangeEvent'
+components:
+  messages:
+    serviceChangeEvent:
+      description: An event describing that Service has been modified (created, updated or deleted)
+      payload:
+        $ref: '#/components/schemas/ServiceChangeEvent'
+  schemas:
+    ServiceChangeEvent:
+      type: object
+      required:
+        - serviceId
+        - serviceView
+        - changeType
+        - timestamp
+      properties:
+        serviceId:
+          type: string
+        serviceView:
+          type: object
+          schema:
+            $ref: '#/components/schemas/ServiceView'
+        changeType:
+          type: string
+          enum:
+            - CREATED
+            - UPDATED
+            - DELETED
+        timestamp:
+          type: number
+          format: int32
+      additionalProperties: true
+    ServiceView:
+      description: Aggregate bean for grouping a Service an its messages pairs
+      type: object
+      required:
+        - service
+        - messagesMap
+      properties:
+        service:
+          $ref: '#/components/schemas/Service'
+          description: Wrapped service description
+        messagesMap:
+          type: object
+          description: "Map of messages for this Service. Keys are operation name,\
+            \ values are array of messages for this operation"
+          additionalProperties:
+            $ref: '#/components/schemas/MessageArray'
+      additionalProperties: true
+    Service:
+      description: Represents a Service or API definition as registred into Microcks
+        repository
+      required:
+        - name
+        - version
+        - type
+        - sourceArtifact
+      properties:
+        id:
+          description: Unique identifier for this Service or API
+          type: string
+        name:
+          description: Distinct name for this Service or API (maybe shared among many
+            versions)
+          type: string
+        version:
+          description: Distinct version for a named Service or API
+          type: string
+        type:
+          description: Service or API Type
+          type: string
+          enum:
+            - REST
+            - SOAP_HTTP
+            - GENERIC_REST
+            - GENERIC_EVENT
+            - EVENT
+            - GRPC
+            - GRAPHQL
+        operations:
+          description: Set of Operations for Service or API
+          type: array
+          items:
+            $ref: '#/components/schemas/Operation'
+        xmlNS:
+          description: Associated Xml Namespace in case of Xml based Service
+          type: string
+        metadata:
+          $ref: '#/components/schemas/Metadata'
+          description: Metadata of Service
+        sourceArtifact:
+          description: Short name of the main/primary artifact this service was created
+            from
+          type: string
+    Metadata:
+      description: Commodity object for holding metadata on any entity. This object
+        is inspired by Kubernetes metadata.
+      type: object
+      required:
+        - createdOn
+        - lastUpdate
+      properties:
+        createdOn:
+          description: Creation date of attached object
+          type: number
+          readOnly: true
+        lastUpdate:
+          description: Last update of attached object
+          type: number
+          readOnly: true
+        annotations:
+          description: Annotations of attached object
+          type: object
+          additionalProperties:
+            type: string
+        labels:
+          description: Labels put on attached object
+          type: object
+          additionalProperties:
+            type: string
+    Operation:
+      description: An Operation of a Service or API
+      type: object
+      required:
+        - name
+        - method
+      properties:
+        name:
+          description: Unique name of this Operation within Service scope
+          type: string
+        method:
+          description: Represents transport method
+          type: string
+        inputName:
+          description: Name of input parameters in case of Xml based Service
+          type: string
+        outputName:
+          description: Name of output parameters in case of Xml based Service
+          type: string
+        dispatcher:
+          description: Dispatcher strategy used for mocks
+          type: string
+        dispatcherRules:
+          description: DispatcherRules used for mocks
+          type: string
+        defaultDelay:
+          description: Default response time delay for mocks
+          type: number
+        resourcePaths:
+          description: Paths the mocks endpoints are mapped on
+          type: array
+          items:
+            type: string
+        parameterContraints:
+          description: Contraints that may apply to mock invocatino on this operation
+          type: array
+          items:
+            $ref: '#/components/schemas/ParameterConstraint'
+        bindings:
+          description: Map of protocol binding details for this operation
+          type: object
+          additionalProperties:
+            $ref: '#/components/schemas/Binding'
+    ParameterConstraint:
+      description: Companion object for Operation that may be used to express constraints
+        on request parameters
+      type: object
+      required:
+        - name
+      properties:
+        name:
+          description: Parameter name
+          type: string
+        required:
+          description: Whether it's a required constraint
+          type: boolean
+        recopy:
+          description: Whether it's a recopy constraint
+          type: boolean
+        mustMatchRegexp:
+          description: Whether it's a regular expression matching constraint
+          type: string
+        in:
+          description: Parameter location
+          type: string
+          enum:
+            - path
+            - query
+            - header
+    Binding:
+      description: Protocol binding details for asynchronous operations
+      type: object
+      required:
+        - type
+        - destinationName
+      properties:
+        type:
+          description: Protocol binding identifier
+          type: string
+          enum:
+            - KAFKA
+            - MQTT
+            - WS
+            - AMQP
+            - NATS
+            - GOOGLEPUBSUB
+            - SQS
+            - SNS
+        keyType:
+          description: Type of key for Kafka messages
+          type: string
+        destinationType:
+          description: Type of destination for asynchronous messages of this operation
+          type: string
+        destinationName:
+          description: Name of destination for asynchronous messages of this operation
+          type: string
+        qoS:
+          description: Quality of Service attribute for MQTT binding
+          type: string
+        persistent:
+          description: Persistent attribute for MQTT binding
+          type: boolean
+        method:
+          description: HTTP method for WebSocket binding
+          type: string
+    MessageArray:
+      description: Array of Message for Service operations
+      type: array
+      items:
+        $ref: '#/components/schemas/Exchange'
+    Exchange:
+      description: "Abstract representation of a Service or API exchange type (request/response,\
+        \ event based, ...)"
+      oneOf:
+        - $ref: '#/components/schemas/RequestResponsePair'
+        - $ref: '#/components/schemas/UnidirectionalEvent'
+      discriminator: type
+    AbstractExchange:
+      description: Abstract bean representing a Service or API Exchange.
+      type: object
+      required:
+        - type
+      properties:
+        type:
+          description: Discriminant type for identifying kind of exchange
+          type: string
+          enum:
+            - reqRespPair
+            - unidirEvent
+    RequestResponsePair:
+      description: Request associated with corresponding Response
+      type: object
+      allOf:
+        - type: object
+          properties:
+            request:
+              $ref: '#/components/schemas/Request'
+              description: The request part of the pair
+            response:
+              $ref: '#/components/schemas/Response'
+              description: The Response part of the pair
+          required:
+            - request
+            - response
+        - $ref: '#/components/schemas/AbstractExchange'
+    UnidirectionalEvent:
+      description: Representation of an unidirectional exchange as an event message
+      type: object
+      allOf:
+        - type: object
+          required:
+            - eventMessage
+          properties:
+            eventMessage:
+              $ref: '#/components/schemas/EventMessage'
+              description: Asynchronous message for this unidirectional event
+        - $ref: '#/components/schemas/AbstractExchange'
+    Request:
+      description: A mock invocation or test request
+      required:
+        - name
+        - operationId
+      properties:
+        id:
+          description: Unique identifier of Request
+          type: string
+        name:
+          description: Unique distinct name of this Request
+          type: string
+        content:
+          description: Body content for this request
+          type: string
+        operationId:
+          description: Identifier of Operation this Request is associated to
+          type: string
+        testCaseId:
+          description: Unique identifier of TestCase this Request is attached (in
+            case of a test)
+          type: string
+        headers:
+          description: Headers for this Request
+          type: array
+          items:
+            $ref: '#/components/schemas/Header'
+    Response:
+      description: A mock invocation or test response
+      required:
+        - operationId
+        - name
+      properties:
+        operationId:
+          description: Identifier of Operation this Response is associated to
+          type: string
+        content:
+          description: Body content of this Response
+          type: string
+        id:
+          description: Unique identifier of Response
+          type: string
+        name:
+          description: Unique distinct name of this Response
+          type: string
+        testCaseId:
+          description: Unique identifier of TestCase this Response is attached (in
+            case of a test)
+          type: string
+        headers:
+          description: Headers for this Response
+          type: array
+          items:
+            $ref: '#/components/schemas/Header'
+    Header:
+      description: Transport headers for both Requests and Responses
+      required:
+        - name
+        - values
+      type: object
+      properties:
+        name:
+          description: Unique distinct name of this Header
+          type: string
+        values:
+          description: Values for this Header
+          type: array
+          items:
+            type: string
+    EventMessage:
+      description: A mock event message
+      required:
+        - id
+        - mediaType
+      type: object
+      properties:
+        id:
+          description: Unique identifier of this message
+          type: string
+        mediaType:
+          description: Content type of message
+          type: string
+        name:
+          description: Unique distinct name of this message
+          type: string
+        content:
+          description: Body content for this message
+          type: string
+        operationId:
+          description: Identifier of Operation this message is associated to
+          type: string
+        testCaseId:
+          description: Unique identifier of TestCase this message is attached (in
+            case of a test)
+          type: string
+        headers:
+          description: Headers for this message
+          type: array
+          items:
+            $ref: '#/components/schemas/Header'

--- a/core-extra/asyncapi-parser/src/test/resources/asyncapi/sut/ncs-amqp.yaml
+++ b/core-extra/asyncapi-parser/src/test/resources/asyncapi/sut/ncs-amqp.yaml
@@ -1,0 +1,324 @@
+# The NCS numerical service, re-expressed as an event-driven API over AMQP 0-9-1.
+# Written for EvoMaster; not taken from a third party.
+asyncapi: 3.0.0
+info:
+  title: NCS over AMQP
+  version: 1.0.0
+  description: |
+    Request/reply model of the **NCS** (Numerical Case Study) SUT from the EvoMaster
+    Dataset (`jdk_8_maven/cs/rest/artificial/ncs`), re-expressed as an event-driven API
+    over **AMQP 0-9-1** (e.g. RabbitMQ).
+
+    NCS is a stateless numerical service: each operation takes a few numbers and returns a
+    computed result. The six original REST endpoints map one-to-one to request/reply
+    operations here — a client publishes a request to the operation's request queue, and the
+    service (the SUT) replies on the operation's reply queue. Error replies mirror the REST
+    4xx responses.
+
+    Correlation between a request and its reply travels in the AMQP **`correlation-id`
+    message property** (modelled here as the `correlationId` header).
+defaultContentType: application/json
+
+servers:
+  rabbitmq:
+    host: localhost:5672
+    protocol: amqp
+    description: AMQP 0-9-1 broker (RabbitMQ) carrying the NCS request and reply queues.
+
+channels:
+  triangleRequest:
+    address: ncs.triangle.request
+    messages:
+      triangleRequest:
+        $ref: '#/components/messages/triangleRequest'
+    bindings:
+      amqp:
+        is: queue
+  triangleReply:
+    address: ncs.triangle.reply
+    messages:
+      result:
+        $ref: '#/components/messages/intResult'
+    bindings:
+      amqp:
+        is: queue
+
+  bessjRequest:
+    address: ncs.bessj.request
+    messages:
+      bessjRequest:
+        $ref: '#/components/messages/bessjRequest'
+    bindings:
+      amqp:
+        is: queue
+  bessjReply:
+    address: ncs.bessj.reply
+    messages:
+      result:
+        $ref: '#/components/messages/doubleResult'
+      error:
+        $ref: '#/components/messages/error'
+    bindings:
+      amqp:
+        is: queue
+
+  expintRequest:
+    address: ncs.expint.request
+    messages:
+      expintRequest:
+        $ref: '#/components/messages/expintRequest'
+    bindings:
+      amqp:
+        is: queue
+  expintReply:
+    address: ncs.expint.reply
+    messages:
+      result:
+        $ref: '#/components/messages/doubleResult'
+      error:
+        $ref: '#/components/messages/error'
+    bindings:
+      amqp:
+        is: queue
+
+  fisherRequest:
+    address: ncs.fisher.request
+    messages:
+      fisherRequest:
+        $ref: '#/components/messages/fisherRequest'
+    bindings:
+      amqp:
+        is: queue
+  fisherReply:
+    address: ncs.fisher.reply
+    messages:
+      result:
+        $ref: '#/components/messages/doubleResult'
+      error:
+        $ref: '#/components/messages/error'
+    bindings:
+      amqp:
+        is: queue
+
+  gammqRequest:
+    address: ncs.gammq.request
+    messages:
+      gammqRequest:
+        $ref: '#/components/messages/gammqRequest'
+    bindings:
+      amqp:
+        is: queue
+  gammqReply:
+    address: ncs.gammq.reply
+    messages:
+      result:
+        $ref: '#/components/messages/doubleResult'
+      error:
+        $ref: '#/components/messages/error'
+    bindings:
+      amqp:
+        is: queue
+
+  remainderRequest:
+    address: ncs.remainder.request
+    messages:
+      remainderRequest:
+        $ref: '#/components/messages/remainderRequest'
+    bindings:
+      amqp:
+        is: queue
+  remainderReply:
+    address: ncs.remainder.reply
+    messages:
+      result:
+        $ref: '#/components/messages/intResult'
+      error:
+        $ref: '#/components/messages/error'
+    bindings:
+      amqp:
+        is: queue
+
+operations:
+  checkTriangle:
+    action: receive
+    summary: Classify a triangle from three integer edges (REST GET /api/triangle/{a}/{b}/{c}).
+    channel:
+      $ref: '#/channels/triangleRequest'
+    reply:
+      channel:
+        $ref: '#/channels/triangleReply'
+  bessj:
+    action: receive
+    summary: Bessel function J_n(x) (REST GET /api/bessj/{n}/{x}).
+    channel:
+      $ref: '#/channels/bessjRequest'
+    reply:
+      channel:
+        $ref: '#/channels/bessjReply'
+  expint:
+    action: receive
+    summary: Exponential integral E_n(x) (REST GET /api/expint/{n}/{x}).
+    channel:
+      $ref: '#/channels/expintRequest'
+    reply:
+      channel:
+        $ref: '#/channels/expintReply'
+  fisher:
+    action: receive
+    summary: Fisher F-distribution value (REST GET /api/fisher/{m}/{n}/{x}).
+    channel:
+      $ref: '#/channels/fisherRequest'
+    reply:
+      channel:
+        $ref: '#/channels/fisherReply'
+  gammq:
+    action: receive
+    summary: Incomplete gamma function Q(a, x) (REST GET /api/gammq/{a}/{x}).
+    channel:
+      $ref: '#/channels/gammqRequest'
+    reply:
+      channel:
+        $ref: '#/channels/gammqReply'
+  remainder:
+    action: receive
+    summary: Integer remainder of a / b (REST GET /api/remainder/{a}/{b}).
+    channel:
+      $ref: '#/channels/remainderRequest'
+    reply:
+      channel:
+        $ref: '#/channels/remainderReply'
+
+components:
+  messages:
+    triangleRequest:
+      name: TriangleRequest
+      title: Triangle classification request
+      contentType: application/json
+      correlationId:
+        location: '$message.header#/correlationId'
+      payload:
+        $ref: '#/components/schemas/TriangleRequest'
+    bessjRequest:
+      name: BessjRequest
+      contentType: application/json
+      correlationId:
+        location: '$message.header#/correlationId'
+      payload:
+        $ref: '#/components/schemas/BessjRequest'
+    expintRequest:
+      name: ExpintRequest
+      contentType: application/json
+      correlationId:
+        location: '$message.header#/correlationId'
+      payload:
+        $ref: '#/components/schemas/ExpintRequest'
+    fisherRequest:
+      name: FisherRequest
+      contentType: application/json
+      correlationId:
+        location: '$message.header#/correlationId'
+      payload:
+        $ref: '#/components/schemas/FisherRequest'
+    gammqRequest:
+      name: GammqRequest
+      contentType: application/json
+      correlationId:
+        location: '$message.header#/correlationId'
+      payload:
+        $ref: '#/components/schemas/GammqRequest'
+    remainderRequest:
+      name: RemainderRequest
+      contentType: application/json
+      correlationId:
+        location: '$message.header#/correlationId'
+      payload:
+        $ref: '#/components/schemas/RemainderRequest'
+    intResult:
+      name: IntResult
+      title: Integer result reply (Dto.resultAsInt)
+      contentType: application/json
+      correlationId:
+        location: '$message.header#/correlationId'
+      payload:
+        $ref: '#/components/schemas/IntResult'
+    doubleResult:
+      name: DoubleResult
+      title: Floating-point result reply (Dto.resultAsDouble)
+      contentType: application/json
+      correlationId:
+        location: '$message.header#/correlationId'
+      payload:
+        $ref: '#/components/schemas/DoubleResult'
+    error:
+      name: Error
+      title: Error reply (mirrors a REST 4xx response)
+      contentType: application/json
+      correlationId:
+        location: '$message.header#/correlationId'
+      payload:
+        $ref: '#/components/schemas/Error'
+
+  schemas:
+    TriangleRequest:
+      type: object
+      required: [a, b, c]
+      properties:
+        a: { type: integer, format: int32, description: First edge }
+        b: { type: integer, format: int32, description: Second edge }
+        c: { type: integer, format: int32, description: Third edge }
+    BessjRequest:
+      type: object
+      required: [n, x]
+      properties:
+        n:
+          type: integer
+          format: int32
+          minimum: 3
+          maximum: 1000
+          description: Order; the service replies with an error outside 3..1000.
+        x: { type: number, format: double }
+    ExpintRequest:
+      type: object
+      required: [n, x]
+      properties:
+        n: { type: integer, format: int32, minimum: 0 }
+        x: { type: number, format: double, description: x >= 0; the service errors otherwise. }
+    FisherRequest:
+      type: object
+      required: [m, n, x]
+      properties:
+        m: { type: integer, format: int32, minimum: 1, maximum: 1000 }
+        n: { type: integer, format: int32, minimum: 1, maximum: 1000 }
+        x: { type: number, format: double }
+    GammqRequest:
+      type: object
+      required: [a, x]
+      properties:
+        a: { type: number, format: double, description: a > 0; the service errors otherwise. }
+        x: { type: number, format: double, description: x >= 0. }
+    RemainderRequest:
+      type: object
+      required: [a, b]
+      properties:
+        a: { type: integer, format: int32, minimum: -10000, maximum: 10000 }
+        b: { type: integer, format: int32, minimum: -10000, maximum: 10000 }
+    IntResult:
+      type: object
+      required: [resultAsInt]
+      properties:
+        resultAsInt: { type: integer, format: int32 }
+    DoubleResult:
+      type: object
+      required: [resultAsDouble]
+      properties:
+        resultAsDouble: { type: number, format: double }
+    Error:
+      type: object
+      required: [error]
+      properties:
+        error:
+          type: object
+          required: [code, message]
+          properties:
+            code: { type: integer, description: 'Mirrors the REST status (e.g. 400).' }
+            message: { type: string }

--- a/core-extra/asyncapi-parser/src/test/resources/asyncapi/sut/ncs-kafka.yaml
+++ b/core-extra/asyncapi-parser/src/test/resources/asyncapi/sut/ncs-kafka.yaml
@@ -1,0 +1,288 @@
+# The NCS numerical service, re-expressed as an event-driven API over Kafka.
+# Written for EvoMaster; not taken from a third party.
+asyncapi: 3.0.0
+info:
+  title: NCS over Kafka
+  version: 1.0.0
+  description: |
+    Request/reply model of the **NCS** (Numerical Case Study) SUT from the EvoMaster
+    Dataset (`jdk_8_maven/cs/rest/artificial/ncs`), re-expressed as an event-driven API
+    over **Kafka**.
+
+    NCS is a stateless numerical service: each operation takes a few numbers and returns a
+    computed result. The six original REST endpoints map one-to-one to request/reply
+    operations here — a client publishes a request on the operation's request topic, and the
+    service (the SUT) replies on the operation's reply topic. Error replies mirror the REST
+    4xx responses (e.g. an out-of-range argument).
+
+    Correlation between a request and its reply travels in a **Kafka message header**
+    (`correlationId`).
+defaultContentType: application/json
+
+servers:
+  kafka:
+    host: localhost:9092
+    protocol: kafka
+    description: Kafka broker carrying the NCS request and reply topics.
+
+channels:
+  triangleRequest:
+    address: ncs.triangle.request
+    messages:
+      triangleRequest:
+        $ref: '#/components/messages/triangleRequest'
+  triangleReply:
+    address: ncs.triangle.reply
+    messages:
+      result:
+        $ref: '#/components/messages/intResult'
+
+  bessjRequest:
+    address: ncs.bessj.request
+    messages:
+      bessjRequest:
+        $ref: '#/components/messages/bessjRequest'
+  bessjReply:
+    address: ncs.bessj.reply
+    messages:
+      result:
+        $ref: '#/components/messages/doubleResult'
+      error:
+        $ref: '#/components/messages/error'
+
+  expintRequest:
+    address: ncs.expint.request
+    messages:
+      expintRequest:
+        $ref: '#/components/messages/expintRequest'
+  expintReply:
+    address: ncs.expint.reply
+    messages:
+      result:
+        $ref: '#/components/messages/doubleResult'
+      error:
+        $ref: '#/components/messages/error'
+
+  fisherRequest:
+    address: ncs.fisher.request
+    messages:
+      fisherRequest:
+        $ref: '#/components/messages/fisherRequest'
+  fisherReply:
+    address: ncs.fisher.reply
+    messages:
+      result:
+        $ref: '#/components/messages/doubleResult'
+      error:
+        $ref: '#/components/messages/error'
+
+  gammqRequest:
+    address: ncs.gammq.request
+    messages:
+      gammqRequest:
+        $ref: '#/components/messages/gammqRequest'
+  gammqReply:
+    address: ncs.gammq.reply
+    messages:
+      result:
+        $ref: '#/components/messages/doubleResult'
+      error:
+        $ref: '#/components/messages/error'
+
+  remainderRequest:
+    address: ncs.remainder.request
+    messages:
+      remainderRequest:
+        $ref: '#/components/messages/remainderRequest'
+  remainderReply:
+    address: ncs.remainder.reply
+    messages:
+      result:
+        $ref: '#/components/messages/intResult'
+      error:
+        $ref: '#/components/messages/error'
+
+operations:
+  checkTriangle:
+    action: receive
+    summary: Classify a triangle from three integer edges (REST GET /api/triangle/{a}/{b}/{c}).
+    channel:
+      $ref: '#/channels/triangleRequest'
+    reply:
+      channel:
+        $ref: '#/channels/triangleReply'
+  bessj:
+    action: receive
+    summary: Bessel function J_n(x) (REST GET /api/bessj/{n}/{x}).
+    channel:
+      $ref: '#/channels/bessjRequest'
+    reply:
+      channel:
+        $ref: '#/channels/bessjReply'
+  expint:
+    action: receive
+    summary: Exponential integral E_n(x) (REST GET /api/expint/{n}/{x}).
+    channel:
+      $ref: '#/channels/expintRequest'
+    reply:
+      channel:
+        $ref: '#/channels/expintReply'
+  fisher:
+    action: receive
+    summary: Fisher F-distribution value (REST GET /api/fisher/{m}/{n}/{x}).
+    channel:
+      $ref: '#/channels/fisherRequest'
+    reply:
+      channel:
+        $ref: '#/channels/fisherReply'
+  gammq:
+    action: receive
+    summary: Incomplete gamma function Q(a, x) (REST GET /api/gammq/{a}/{x}).
+    channel:
+      $ref: '#/channels/gammqRequest'
+    reply:
+      channel:
+        $ref: '#/channels/gammqReply'
+  remainder:
+    action: receive
+    summary: Integer remainder of a / b (REST GET /api/remainder/{a}/{b}).
+    channel:
+      $ref: '#/channels/remainderRequest'
+    reply:
+      channel:
+        $ref: '#/channels/remainderReply'
+
+components:
+  messages:
+    triangleRequest:
+      name: TriangleRequest
+      title: Triangle classification request
+      contentType: application/json
+      correlationId:
+        location: '$message.header#/correlationId'
+      payload:
+        $ref: '#/components/schemas/TriangleRequest'
+    bessjRequest:
+      name: BessjRequest
+      contentType: application/json
+      correlationId:
+        location: '$message.header#/correlationId'
+      payload:
+        $ref: '#/components/schemas/BessjRequest'
+    expintRequest:
+      name: ExpintRequest
+      contentType: application/json
+      correlationId:
+        location: '$message.header#/correlationId'
+      payload:
+        $ref: '#/components/schemas/ExpintRequest'
+    fisherRequest:
+      name: FisherRequest
+      contentType: application/json
+      correlationId:
+        location: '$message.header#/correlationId'
+      payload:
+        $ref: '#/components/schemas/FisherRequest'
+    gammqRequest:
+      name: GammqRequest
+      contentType: application/json
+      correlationId:
+        location: '$message.header#/correlationId'
+      payload:
+        $ref: '#/components/schemas/GammqRequest'
+    remainderRequest:
+      name: RemainderRequest
+      contentType: application/json
+      correlationId:
+        location: '$message.header#/correlationId'
+      payload:
+        $ref: '#/components/schemas/RemainderRequest'
+    intResult:
+      name: IntResult
+      title: Integer result reply (Dto.resultAsInt)
+      contentType: application/json
+      correlationId:
+        location: '$message.header#/correlationId'
+      payload:
+        $ref: '#/components/schemas/IntResult'
+    doubleResult:
+      name: DoubleResult
+      title: Floating-point result reply (Dto.resultAsDouble)
+      contentType: application/json
+      correlationId:
+        location: '$message.header#/correlationId'
+      payload:
+        $ref: '#/components/schemas/DoubleResult'
+    error:
+      name: Error
+      title: Error reply (mirrors a REST 4xx response)
+      contentType: application/json
+      correlationId:
+        location: '$message.header#/correlationId'
+      payload:
+        $ref: '#/components/schemas/Error'
+
+  schemas:
+    TriangleRequest:
+      type: object
+      required: [a, b, c]
+      properties:
+        a: { type: integer, format: int32, description: First edge }
+        b: { type: integer, format: int32, description: Second edge }
+        c: { type: integer, format: int32, description: Third edge }
+    BessjRequest:
+      type: object
+      required: [n, x]
+      properties:
+        n:
+          type: integer
+          format: int32
+          minimum: 3
+          maximum: 1000
+          description: Order; the service replies with an error outside 3..1000.
+        x: { type: number, format: double }
+    ExpintRequest:
+      type: object
+      required: [n, x]
+      properties:
+        n: { type: integer, format: int32, minimum: 0 }
+        x: { type: number, format: double, description: x >= 0; the service errors otherwise. }
+    FisherRequest:
+      type: object
+      required: [m, n, x]
+      properties:
+        m: { type: integer, format: int32, minimum: 1, maximum: 1000 }
+        n: { type: integer, format: int32, minimum: 1, maximum: 1000 }
+        x: { type: number, format: double }
+    GammqRequest:
+      type: object
+      required: [a, x]
+      properties:
+        a: { type: number, format: double, description: a > 0; the service errors otherwise. }
+        x: { type: number, format: double, description: x >= 0. }
+    RemainderRequest:
+      type: object
+      required: [a, b]
+      properties:
+        a: { type: integer, format: int32, minimum: -10000, maximum: 10000 }
+        b: { type: integer, format: int32, minimum: -10000, maximum: 10000 }
+    IntResult:
+      type: object
+      required: [resultAsInt]
+      properties:
+        resultAsInt: { type: integer, format: int32 }
+    DoubleResult:
+      type: object
+      required: [resultAsDouble]
+      properties:
+        resultAsDouble: { type: number, format: double }
+    Error:
+      type: object
+      required: [error]
+      properties:
+        error:
+          type: object
+          required: [code, message]
+          properties:
+            code: { type: integer, description: 'Mirrors the REST status (e.g. 400).' }
+            message: { type: string }

--- a/core-extra/asyncapi-parser/src/test/resources/asyncapi/sut/openagents-cache.yaml
+++ b/core-extra/asyncapi-parser/src/test/resources/asyncapi/sut/openagents-cache.yaml
@@ -1,0 +1,447 @@
+# Source: the OpenAgents shared-cache API (MIT), unmodified.
+asyncapi: '3.0.0'
+info:
+  title: OpenAgents Core Shared Cache Mod API
+  version: '1.0.0'
+  description: |
+    A shared caching system for OpenAgents with agent group-based access control.
+
+    ## Features
+    - Create cache entries with MIME type support
+    - Agent group-based access control
+    - Get, update, and delete cache entries
+    - Real-time notifications for cache changes
+    - Persistent storage in workspace
+
+  contact:
+    name: OpenAgents Team
+  license:
+    name: MIT
+
+defaultContentType: application/json
+
+channels:
+  cacheCreate:
+    address: shared_cache.create
+    messages:
+      cacheCreate:
+        $ref: '#/components/messages/CacheCreateMessage'
+
+  cacheGet:
+    address: shared_cache.get
+    messages:
+      cacheGet:
+        $ref: '#/components/messages/CacheGetMessage'
+
+  cacheUpdate:
+    address: shared_cache.update
+    messages:
+      cacheUpdate:
+        $ref: '#/components/messages/CacheUpdateMessage'
+
+  cacheDelete:
+    address: shared_cache.delete
+    messages:
+      cacheDelete:
+        $ref: '#/components/messages/CacheDeleteMessage'
+
+  cacheCreateResponse:
+    address: shared_cache.create.response
+    messages:
+      cacheCreateResponse:
+        $ref: '#/components/messages/CacheCreateResponse'
+
+  cacheGetResponse:
+    address: shared_cache.get.response
+    messages:
+      cacheGetResponse:
+        $ref: '#/components/messages/CacheGetResponse'
+
+  cacheUpdateResponse:
+    address: shared_cache.update.response
+    messages:
+      cacheUpdateResponse:
+        $ref: '#/components/messages/CacheUpdateResponse'
+
+  cacheDeleteResponse:
+    address: shared_cache.delete.response
+    messages:
+      cacheDeleteResponse:
+        $ref: '#/components/messages/CacheDeleteResponse'
+
+  cacheCreatedNotification:
+    address: shared_cache.notification.created
+    messages:
+      cacheCreatedNotification:
+        $ref: '#/components/messages/CacheCreatedNotification'
+
+  cacheUpdatedNotification:
+    address: shared_cache.notification.updated
+    messages:
+      cacheUpdatedNotification:
+        $ref: '#/components/messages/CacheUpdatedNotification'
+
+  cacheDeletedNotification:
+    address: shared_cache.notification.deleted
+    messages:
+      cacheDeletedNotification:
+        $ref: '#/components/messages/CacheDeletedNotification'
+
+operations:
+  createCache:
+    action: send
+    channel:
+      $ref: '#/channels/cacheCreate'
+    summary: Create a new cache entry with optional agent group access control
+
+  getCache:
+    action: send
+    channel:
+      $ref: '#/channels/cacheGet'
+    summary: Retrieve a cache entry by ID
+
+  updateCache:
+    action: send
+    channel:
+      $ref: '#/channels/cacheUpdate'
+    summary: Update an existing cache entry
+
+  deleteCache:
+    action: send
+    channel:
+      $ref: '#/channels/cacheDelete'
+    summary: Delete a cache entry
+
+  # Receive operations
+  receiveCacheCreateResponse:
+    action: receive
+    channel:
+      $ref: '#/channels/cacheCreateResponse'
+    summary: Receive cache creation response
+
+  receiveCacheGetResponse:
+    action: receive
+    channel:
+      $ref: '#/channels/cacheGetResponse'
+    summary: Receive cache retrieval response
+
+  receiveCacheUpdateResponse:
+    action: receive
+    channel:
+      $ref: '#/channels/cacheUpdateResponse'
+    summary: Receive cache update response
+
+  receiveCacheDeleteResponse:
+    action: receive
+    channel:
+      $ref: '#/channels/cacheDeleteResponse'
+    summary: Receive cache deletion response
+
+  receiveCacheCreatedNotification:
+    action: receive
+    channel:
+      $ref: '#/channels/cacheCreatedNotification'
+    summary: Receive notification when a cache entry is created
+
+  receiveCacheUpdatedNotification:
+    action: receive
+    channel:
+      $ref: '#/channels/cacheUpdatedNotification'
+    summary: Receive notification when a cache entry is updated
+
+  receiveCacheDeletedNotification:
+    action: receive
+    channel:
+      $ref: '#/channels/cacheDeletedNotification'
+    summary: Receive notification when a cache entry is deleted
+
+components:
+  parameters:
+    cacheId:
+      description: The unique identifier of a cache entry (UUID)
+
+    agentId:
+      description: The unique identifier of an agent in the OpenAgents network
+
+    agentGroup:
+      description: The name of an agent group
+
+  messages:
+    CacheCreateMessage:
+      name: CacheCreateMessage
+      title: Cache Create
+      summary: Create a new cache entry
+      contentType: application/json
+      x_event_type: operation
+      payload:
+        $ref: '#/components/schemas/CacheCreatePayload'
+
+    CacheGetMessage:
+      name: CacheGetMessage
+      title: Cache Get
+      summary: Retrieve a cache entry
+      contentType: application/json
+      x_event_type: operation
+      payload:
+        $ref: '#/components/schemas/CacheGetPayload'
+
+    CacheUpdateMessage:
+      name: CacheUpdateMessage
+      title: Cache Update
+      summary: Update a cache entry
+      contentType: application/json
+      x_event_type: operation
+      payload:
+        $ref: '#/components/schemas/CacheUpdatePayload'
+
+    CacheDeleteMessage:
+      name: CacheDeleteMessage
+      title: Cache Delete
+      summary: Delete a cache entry
+      contentType: application/json
+      x_event_type: operation
+      payload:
+        $ref: '#/components/schemas/CacheDeletePayload'
+
+    # Response messages
+    CacheCreateResponse:
+      name: CacheCreateResponse
+      title: Cache Create Response
+      summary: Response to cache creation operation
+      contentType: application/json
+      x_event_type: response
+      payload:
+        $ref: '#/components/schemas/CacheCreateResponsePayload'
+
+    CacheGetResponse:
+      name: CacheGetResponse
+      title: Cache Get Response
+      summary: Response to cache retrieval operation
+      contentType: application/json
+      x_event_type: response
+      payload:
+        $ref: '#/components/schemas/CacheGetResponsePayload'
+
+    CacheUpdateResponse:
+      name: CacheUpdateResponse
+      title: Cache Update Response
+      summary: Response to cache update operation
+      contentType: application/json
+      x_event_type: response
+      payload:
+        $ref: '#/components/schemas/CacheUpdateResponsePayload'
+
+    CacheDeleteResponse:
+      name: CacheDeleteResponse
+      title: Cache Delete Response
+      summary: Response to cache deletion operation
+      contentType: application/json
+      x_event_type: response
+      payload:
+        $ref: '#/components/schemas/CacheDeleteResponsePayload'
+
+    # Notification messages
+    CacheCreatedNotification:
+      name: CacheCreatedNotification
+      title: Cache Created Notification
+      summary: Notification when a cache entry is created
+      contentType: application/json
+      x_event_type: notification
+      payload:
+        $ref: '#/components/schemas/CacheNotificationPayload'
+
+    CacheUpdatedNotification:
+      name: CacheUpdatedNotification
+      title: Cache Updated Notification
+      summary: Notification when a cache entry is updated
+      contentType: application/json
+      x_event_type: notification
+      payload:
+        $ref: '#/components/schemas/CacheNotificationPayload'
+
+    CacheDeletedNotification:
+      name: CacheDeletedNotification
+      title: Cache Deleted Notification
+      summary: Notification when a cache entry is deleted
+      contentType: application/json
+      x_event_type: notification
+      payload:
+        $ref: '#/components/schemas/CacheNotificationPayload'
+
+  schemas:
+    CacheCreatePayload:
+      type: object
+      required:
+        - value
+      properties:
+        value:
+          type: string
+          description: The value to cache (stored as string)
+          example: "This is cached data"
+        mime_type:
+          type: string
+          description: MIME type of the cached value
+          default: "text/plain"
+          example: "application/json"
+        allowed_agent_groups:
+          type: array
+          items:
+            type: string
+          description: List of agent groups that can access this cache (empty = all agents)
+          default: []
+          example: ["admin", "developers"]
+
+    CacheGetPayload:
+      type: object
+      required:
+        - cache_id
+      properties:
+        cache_id:
+          type: string
+          description: UUID of the cache entry to retrieve
+          example: "550e8400-e29b-41d4-a716-446655440000"
+
+    CacheUpdatePayload:
+      type: object
+      required:
+        - cache_id
+        - value
+      properties:
+        cache_id:
+          type: string
+          description: UUID of the cache entry to update
+          example: "550e8400-e29b-41d4-a716-446655440000"
+        value:
+          type: string
+          description: New value for the cache entry
+          example: "Updated cached data"
+
+    CacheDeletePayload:
+      type: object
+      required:
+        - cache_id
+      properties:
+        cache_id:
+          type: string
+          description: UUID of the cache entry to delete
+          example: "550e8400-e29b-41d4-a716-446655440000"
+
+    # Response payload schemas
+    CacheCreateResponsePayload:
+      type: object
+      required:
+        - success
+      properties:
+        success:
+          type: boolean
+          description: Whether the cache creation was successful
+        cache_id:
+          type: string
+          description: UUID of the created cache entry (only present if success=true)
+          example: "550e8400-e29b-41d4-a716-446655440000"
+        error:
+          type: string
+          description: Error message if unsuccessful
+          example: "value is required"
+
+    CacheGetResponsePayload:
+      type: object
+      required:
+        - success
+      properties:
+        success:
+          type: boolean
+          description: Whether the cache retrieval was successful
+        cache_id:
+          type: string
+          description: UUID of the cache entry
+          example: "550e8400-e29b-41d4-a716-446655440000"
+        value:
+          type: string
+          description: The cached value (only present if success=true)
+          example: "This is cached data"
+        mime_type:
+          type: string
+          description: MIME type of the cached value
+          example: "application/json"
+        allowed_agent_groups:
+          type: array
+          items:
+            type: string
+          description: List of agent groups that can access this cache
+          example: ["admin", "developers"]
+        created_by:
+          type: string
+          description: ID of the agent who created the cache entry
+          example: "agent_alice"
+        created_at:
+          type: integer
+          description: Unix timestamp when the cache entry was created
+          example: 1699564800
+        updated_at:
+          type: integer
+          description: Unix timestamp when the cache entry was last updated
+          example: 1699651200
+        error:
+          type: string
+          description: Error message if unsuccessful
+          example: "Cache entry not found"
+
+    CacheUpdateResponsePayload:
+      type: object
+      required:
+        - success
+      properties:
+        success:
+          type: boolean
+          description: Whether the cache update was successful
+        cache_id:
+          type: string
+          description: UUID of the updated cache entry (only present if success=true)
+          example: "550e8400-e29b-41d4-a716-446655440000"
+        error:
+          type: string
+          description: Error message if unsuccessful
+          example: "Agent does not have permission to update this cache entry"
+
+    CacheDeleteResponsePayload:
+      type: object
+      required:
+        - success
+      properties:
+        success:
+          type: boolean
+          description: Whether the cache deletion was successful
+        cache_id:
+          type: string
+          description: UUID of the deleted cache entry (only present if success=true)
+          example: "550e8400-e29b-41d4-a716-446655440000"
+        error:
+          type: string
+          description: Error message if unsuccessful
+          example: "Access denied"
+
+    # Notification payload schemas
+    CacheNotificationPayload:
+      type: object
+      required:
+        - cache_id
+      properties:
+        cache_id:
+          type: string
+          description: UUID of the cache entry that was modified
+          example: "550e8400-e29b-41d4-a716-446655440000"
+        mime_type:
+          type: string
+          description: MIME type of the cached value
+          example: "application/json"
+        created_by:
+          type: string
+          description: ID of the agent who created the cache entry
+          example: "agent_alice"
+        allowed_agent_groups:
+          type: array
+          items:
+            type: string
+          description: List of agent groups that can access this cache
+          example: ["admin", "developers"]

--- a/docs/reused_code.md
+++ b/docs/reused_code.md
@@ -15,3 +15,17 @@ are listed here:
   
 * _RegexDistanceUtilsTest.java_: from [EvoSuite](http://www.evosuite.org) unit test generator. 
   Released under GNU Lesser General Public
+* _asyncapi/sut/bookworm-rating.yaml_: AsyncAPI description from
+  [BookWorm](https://github.com/foxminchan/BookWorm), used unmodified as a test resource of the
+  `asyncapi-parser` module. Released under MIT license.
+
+* _asyncapi/sut/everest.yaml_: AsyncAPI description from
+  [EVerest](https://github.com/EVerest/EVerest), used unmodified as a test resource of the
+  `asyncapi-parser` module. Released under Apache-2.0 license.
+
+* _asyncapi/sut/microcks.yaml_: AsyncAPI description from
+  [Microcks](https://github.com/microcks/microcks), used unmodified as a test resource of the
+  `asyncapi-parser` module. Released under Apache-2.0 license.
+
+* _asyncapi/sut/openagents-cache.yaml_: AsyncAPI description of the OpenAgents shared-cache API,
+  used unmodified as a test resource of the `asyncapi-parser` module. Released under MIT license.


### PR DESCRIPTION
Last in the AsyncAPI stack, on top of #4. **Test-only — no production code at all.**

Everything so far is tested against documents written to pin down one thing at a time. This adds six taken as published from real services, because the shapes that actually break a parser are not the ones you think to write yourself.

## What each one is here for

| Document | What it does that nothing else does |
|---|---|
| **microcks** | a channel with no `address` at all, whose topic hides in its Kafka binding; and a channel that adds a message key on top of a *shared* message definition |
| **everest** | a reply whose address is announced inside the request, on a channel that therefore has no address of its own; and a server whose `pathname` is templated |
| **bookworm** | four servers, a content type of its own, and a security scheme written inline on the server rather than in `components` |
| **openagents** | request and response as separate operations with no `reply` between them, written from the *client's* point of view rather than the service's |
| **ncs** (×2) | the same interactions described over Kafka and over AMQP, which is what the bindings have to keep apart |

The four third-party documents are unmodified and carry a comment naming their source and licence (Apache-2.0 ×2, MIT ×2). The two NCS ones were written for EvoMaster. 76 KB in total, which is small next to the existing `swagger/sut` (5.6 MB) and `graphql/online` (23 MB).

The openagents one is worth a look in review: its polarity is inverted relative to what you would expect, because the document describes the agent *using* the cache rather than the service providing it. The parser reports what the document says and nothing more — which end is the system under test is not something the document settles, and that is a real limitation worth being explicit about rather than papering over.

## The sweep tool

`AsyncApiCorpusSweepMain` parses every document in a folder and prints what came of each — version, operation counts, and anything that had to be skipped. It is a research aid rather than a test, in the same spirit as the existing `PetClinicCheckMain`: it is how a change to the parser gets checked against a corpus far too large to check in. It defaults to the documents that ship here, so it runs for anyone who checks the repository out.

For context, the parser has been run this way over ~460 real AsyncAPI documents collected from public repositories. The only ones it declines are documents that are not AsyncAPI at all, and Avro payloads, which it reports rather than mis-parses.

## A note on where these tests live

They are in `AsyncApiParserTest` rather than a class of their own. `docs/for_developers.md` requires a unit test suite for `Foo` to be called `FooTest`, and a separate corpus class would have no class under test; keeping artificial and real-world resources in one suite is also what `RestActionBuilderV3Test` and `GraphQLActionBuilderTest` already do.

80 tests across the package.
---

*Fifth in the AsyncAPI stack. Based on #1708.*
