### PR TITLE
AsyncAPI 3.x: build genes from message payloads

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -284,6 +284,10 @@
             <groupId>org.evomaster</groupId>
             <artifactId>evomaster-dbconstraint</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.evomaster</groupId>
+            <artifactId>asyncapi-parser</artifactId>
+        </dependency>
 
         <!--for token parser-->
         <dependency>

--- a/core/src/main/kotlin/org/evomaster/core/problem/asyncapi/builder/AsyncApiGeneBuilder.kt
+++ b/core/src/main/kotlin/org/evomaster/core/problem/asyncapi/builder/AsyncApiGeneBuilder.kt
@@ -1,0 +1,270 @@
+package org.evomaster.core.problem.asyncapi.builder
+
+import com.fasterxml.jackson.databind.JsonNode
+import com.fasterxml.jackson.databind.node.JsonNodeFactory
+import com.fasterxml.jackson.databind.node.ObjectNode
+import com.webfuzzing.asyncapi.models.AsyncApiDocument
+import com.webfuzzing.asyncapi.models.AsyncApiMessage
+import com.webfuzzing.asyncapi.resolver.AsyncApiRefResolver
+import org.evomaster.core.EMConfig
+import org.evomaster.core.problem.rest.builder.RestActionBuilderV3
+import org.evomaster.core.search.gene.Gene
+
+/**
+ * Turns the JSON Schema of an AsyncAPI message into the genes the search mutates.
+ *
+ * The parser deliberately stops at the schema: it leaves every `$ref` inside a payload alone,
+ * and guarantees that whatever those references reach is present in
+ * [AsyncApiDocument.getComponentSchemas]. That guarantee is what this builder trades on -- it hands
+ * the whole schema map to [RestActionBuilderV3.createGeneForDTO], which wraps it in a synthetic
+ * OpenAPI document and lets the existing machinery resolve the references and build the genes.
+ *
+ * Reusing that machinery rather than writing a second JSON-Schema-to-gene converter means
+ * AsyncAPI payloads get everything REST already has: numeric and length bounds, formats,
+ * `oneOf` as a choice, cycle detection, and optional-versus-required fields.
+ */
+object AsyncApiGeneBuilder {
+
+    /**
+     * Under what name a payload written inline, rather than as a reference to a named schema,
+     * is added to the schema map. The prefix keeps it from colliding with a declared schema.
+     */
+    private const val INLINE_PREFIX = "_asyncapi_"
+
+    /**
+     * The genes for a message's payload, or null when it declares none.
+     */
+    fun buildPayloadGene(
+        schema: AsyncApiDocument,
+        message: AsyncApiMessage,
+        options: RestActionBuilderV3.Options
+    ): Gene? = build(message.payload, "${message.id}.payload", schema, options)
+
+    /**
+     * The genes for a message's headers, or null when it declares none.
+     *
+     * Headers are built separately from the payload because they travel separately on the wire:
+     * a transport with metadata puts them beside the body rather than in it.
+     */
+    fun buildHeadersGene(
+        schema: AsyncApiDocument,
+        message: AsyncApiMessage,
+        options: RestActionBuilderV3.Options
+    ): Gene? = build(message.headers, "${message.id}.headers", schema, options)
+
+    /**
+     * Options for building AsyncAPI payloads.
+     *
+     * Note `invalidData = false`, which is not what REST does. That flag makes the builder add
+     * a bogus "EVOMASTER" member to every enum, on purpose, to probe how a service handles a
+     * value it never declared. In a message payload that backfires: an enum of one value is how
+     * documents write a routing discriminator (`request: {const: list_legs}`, which arrives
+     * here as an enum), and a message carrying a discriminator the service does not recognise
+     * is silently dropped. Half the messages sent would then go nowhere -- wasting executions,
+     * and firing the no-reply fault target for a fault of our own making.
+     *
+     * Nothing is lost for reaching error paths: the bounds that matter are preserved, so a
+     * field declared `minimum: 3` is still fuzzed across its boundary.
+     */
+    fun options(config: EMConfig) = RestActionBuilderV3.Options(
+        enableConstraintHandling = config.enableSchemaConstraintHandling,
+        invalidData = false,
+        usingWhiteBox = !config.blackBox,
+        enableAdvancedFormats = config.enableAdvancedFormats,
+        inferFormatFromNames = config.inferFormatFromNames
+    )
+
+    private fun build(
+        declared: JsonNode?,
+        inlineName: String,
+        schema: AsyncApiDocument,
+        options: RestActionBuilderV3.Options
+    ): Gene? {
+
+        if (declared == null) {
+            return null
+        }
+
+        //a reference that is the whole declaration, so that following it loses nothing
+        val ref = AsyncApiRefResolver.refOf(declared)?.takeIf { isWholeSchemaRef(declared) }
+
+        /*
+            A payload that is just a reference to a declared schema is built under that schema's
+            own name, which keeps the gene named after what the document calls it. Anything else
+            is added to the map under a name of our own.
+
+            Note `refKey` rather than `schemaKeyOf`: only a pointer at the schema itself may be
+            shortcut this way. One that goes deeper names a part of it, and building the whole
+            schema instead would be a different message altogether.
+         */
+        val referenced = ref
+            ?.let { AsyncApiRefResolver.refKey(it, AsyncApiRefResolver.SCHEMA_PREFIX) }
+            ?.takeIf { schema.componentSchemas.containsKey(it) }
+
+        val name = referenced ?: (INLINE_PREFIX + inlineName)
+
+        val schemas = JsonNodeFactory.instance.objectNode()
+        schema.componentSchemas.forEach { (key, node) -> schemas.set<JsonNode>(key, usable(node)) }
+        if (referenced == null) {
+            schemas.set<JsonNode>(name, usable(pointedAt(ref, declared, schema)))
+        }
+
+        //the format createGeneForDTO expects: the name of the wanted schema, then all of them
+        return RestActionBuilderV3.createGeneForDTO(name, "\"$name\":$schemas", options)
+    }
+
+    /**
+     * What a payload stands for when its reference goes deeper than the schema it names.
+     *
+     * `#/components/schemas/Order/properties/item` is a legitimate way of saying "the shape of
+     * that one property", and the parser lets it through: what it checks is that `Order` is
+     * present. It cannot be left to be resolved further down, though. The OpenAPI machinery the
+     * genes are built with follows a reference to a whole schema and nothing else, and answers
+     * a deeper one with an empty object -- which would build a message with no fields at all,
+     * and say nothing about it.
+     *
+     * So the pointer is walked here, against the very component schemas the parser guaranteed
+     * are reachable. Anything else is returned untouched.
+     */
+    private fun pointedAt(ref: String?, declared: JsonNode, schema: AsyncApiDocument): JsonNode {
+
+        if (ref == null) {
+            return declared
+        }
+
+        val tail = ref.removePrefix(AsyncApiRefResolver.SCHEMA_PREFIX).substringAfter('/', "")
+
+        if (tail.isEmpty()) {
+            //the reference names a whole schema, which needs no walking
+            return declared
+        }
+
+        val target = AsyncApiRefResolver.schemaKeyOf(ref)?.let { schema.componentSchemas[it] }
+            ?: return declared
+
+        var current = target
+
+        for (segment in tail.split("/")) {
+            current = current.get(decodePointerSegment(segment))
+                ?: throw IllegalArgumentException(
+                    "The schema refers to '$ref', but '$segment' is not there, so there is no" +
+                            " shape to build from"
+                )
+        }
+
+        if (!current.isObject) {
+            throw IllegalArgumentException(
+                "The schema refers to '$ref', which is not a JSON Schema object, so there is no" +
+                        " shape to build from"
+            )
+        }
+
+        return current
+    }
+
+    /**
+     * JSON Pointer escaping: "~1" is a "/" and "~0" is a "~", undone in that order.
+     */
+    private fun decodePointerSegment(segment: String) =
+        segment.replace("~1", "/").replace("~0", "~")
+
+    /**
+     * Whether the node is nothing but a reference, so that following it loses nothing.
+     */
+    private fun isWholeSchemaRef(node: JsonNode) =
+        node.isObject && node.fieldNames().asSequence().toList() == listOf("\$ref")
+
+    /**
+     * A copy of the schema with the constructs the gene builder cannot read translated into
+     * ones it can. The original is left alone, as it belongs to the parsed document.
+     */
+    private fun usable(node: JsonNode): JsonNode = rewriteConst(node.deepCopy())
+
+    /**
+     * Rewrite every `const` into whatever pins a field to that one value in a form the gene
+     * builder reads.
+     *
+     * `const` is JSON Schema's way of fixing a field to one literal, and documents use it to
+     * mark which message a payload is. The gene builder does not read it at all -- with or
+     * without a `type` beside it, a `const` field becomes a free value, so the discriminator
+     * would be random and the service would not recognise the message.
+     *
+     * Which rewrite is used depends on the kind of literal, because the two available ways of
+     * saying "only this value" do not both work for every type:
+     *
+     * - **text** becomes a single-valued `enum`. Note the builder adds a bogus member to a
+     *   string enum when asked for invalid data, which is why [options] turns that off.
+     * - **numbers** become equal bounds instead. An enum would be read, but the bogus member
+     *   added to a numeric enum is not conditional on anything, so an enum of one value would
+     *   always come back as two. Equal bounds pin the value with no such surprise.
+     * - **booleans** are left alone. There is no enum handling for them and no bounds to set;
+     *   a two-valued field is guessed half the time anyway.
+     *
+     * Only `const` in the position of a keyword is rewritten. The same word can appear as a
+     * field name a document declares, or inside a `default` that happens to have a member of
+     * that name, and rewriting either would corrupt the document rather than help it -- hence
+     * [DATA_KEYWORDS] and [SCHEMA_MAPS].
+     */
+    private fun rewriteConst(node: JsonNode): JsonNode {
+
+        if (node.isArray) {
+            node.forEach { rewriteConst(it) }
+            return node
+        }
+
+        if (!node.isObject) {
+            return node
+        }
+
+        val obj = node as ObjectNode
+        val const = obj.get("const")
+
+        if (const != null && !const.isContainerNode) {
+            when {
+                const.isTextual -> {
+                    obj.remove("const")
+                    obj.putArray("enum").add(const)
+                    obj.put("type", "string")
+                }
+                const.isNumber -> {
+                    obj.remove("const")
+                    obj.set<JsonNode>("minimum", const)
+                    obj.set<JsonNode>("maximum", const)
+                    obj.put("type", if (const.isIntegralNumber) "integer" else "number")
+                }
+                const.isBoolean -> {
+                    obj.remove("const")
+                    obj.put("type", "boolean")
+                }
+            }
+        }
+
+        obj.fields().forEach { (key, value) ->
+            when (key) {
+                /*
+                    These map names a document chose to the schemas describing them, so their
+                    keys are never keywords: whatever is under them is a schema and is walked,
+                    but this level itself is not read as one.
+                 */
+                in SCHEMA_MAPS -> value.fields().forEach { (_, member) -> rewriteConst(member) }
+                //literal data, where a member named "const" is a value and not a keyword
+                in DATA_KEYWORDS -> Unit
+                else -> rewriteConst(value)
+            }
+        }
+
+        return obj
+    }
+
+    /**
+     * The keywords whose value is literal data rather than a schema, so nothing inside them is
+     * a keyword either.
+     */
+    private val DATA_KEYWORDS = setOf("const", "default", "enum", "example", "examples")
+
+    /**
+     * The keywords whose value maps arbitrary names to schemas. Their keys come from the
+     * document, so a field a service happens to call "const" or "default" must still be walked.
+     */
+    private val SCHEMA_MAPS = setOf("properties", "patternProperties", "definitions", "\$defs")
+}

--- a/core/src/main/kotlin/org/evomaster/core/problem/asyncapi/builder/AsyncApiGeneBuilder.kt
+++ b/core/src/main/kotlin/org/evomaster/core/problem/asyncapi/builder/AsyncApiGeneBuilder.kt
@@ -32,6 +32,18 @@ object AsyncApiGeneBuilder {
     private const val INLINE_PREFIX = "_asyncapi_"
 
     /**
+     * The keywords whose value is literal data rather than a schema, so nothing inside them is
+     * a keyword either.
+     */
+    private val DATA_KEYWORDS = setOf("const", "default", "enum", "example", "examples")
+
+    /**
+     * The keywords whose value maps arbitrary names to schemas. Their keys come from the
+     * document, so a field a service happens to call "const" or "default" must still be walked.
+     */
+    private val SCHEMA_MAPS = setOf("properties", "patternProperties", "definitions", "\$defs")
+
+    /**
      * The genes for a message's payload, or null when it declares none.
      */
     fun buildPayloadGene(
@@ -255,16 +267,4 @@ object AsyncApiGeneBuilder {
 
         return obj
     }
-
-    /**
-     * The keywords whose value is literal data rather than a schema, so nothing inside them is
-     * a keyword either.
-     */
-    private val DATA_KEYWORDS = setOf("const", "default", "enum", "example", "examples")
-
-    /**
-     * The keywords whose value maps arbitrary names to schemas. Their keys come from the
-     * document, so a field a service happens to call "const" or "default" must still be walked.
-     */
-    private val SCHEMA_MAPS = setOf("properties", "patternProperties", "definitions", "\$defs")
 }

--- a/core/src/test/kotlin/org/evomaster/core/problem/asyncapi/builder/AsyncApiGeneBuilderTest.kt
+++ b/core/src/test/kotlin/org/evomaster/core/problem/asyncapi/builder/AsyncApiGeneBuilderTest.kt
@@ -1,0 +1,441 @@
+package org.evomaster.core.problem.asyncapi.builder
+
+import com.webfuzzing.asyncapi.access.AsyncApiAccess
+import com.webfuzzing.asyncapi.models.AsyncApiDocument
+import org.evomaster.core.EMConfig
+import org.evomaster.core.problem.rest.builder.RestActionBuilderV3
+import org.evomaster.core.search.gene.BooleanGene
+import org.evomaster.core.search.gene.Gene
+import org.evomaster.core.search.gene.ObjectGene
+import org.evomaster.core.search.gene.collection.ArrayGene
+import org.evomaster.core.search.gene.collection.EnumGene
+import org.evomaster.core.search.gene.numeric.DoubleGene
+import org.evomaster.core.search.gene.numeric.IntegerGene
+import org.evomaster.core.search.gene.string.StringGene
+import org.evomaster.core.search.gene.wrapper.ChoiceGene
+import org.evomaster.core.search.gene.wrapper.OptionalGene
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class AsyncApiGeneBuilderTest {
+
+    private val options = AsyncApiGeneBuilder.options(EMConfig())
+
+    /**
+     * RestActionBuilderV3 keeps its built genes in a static cache, so a test that did not clear
+     * it could be handed one built by another.
+     */
+    @BeforeEach
+    fun reset() {
+        RestActionBuilderV3.cleanCache()
+    }
+
+    private fun payloadOf(resourcePath: String, messageId: String): Gene {
+        val schema = AsyncApiAccess.getAsyncApiFromResource(resourcePath)
+        return AsyncApiGeneBuilder.buildPayloadGene(schema, schema.messages.getValue(messageId), options)!!
+    }
+
+    private fun payloadOf(schema: AsyncApiDocument, messageId: String): Gene =
+        AsyncApiGeneBuilder.buildPayloadGene(schema, schema.messages.getValue(messageId), options)!!
+
+    /**
+     * The gene a field ended up with, unwrapping the optional that a non-required field gets.
+     */
+    private fun field(gene: Gene, name: String): Gene {
+        val obj = gene as ObjectGene
+        val found = obj.fields.first { it.name == name }
+        return if (found is OptionalGene) found.gene else found
+    }
+
+    // ------------------------------------------------------------------ the shape of a payload
+
+    @Test
+    fun testObjectWithRequiredAndOptionalFields() {
+
+        val gene = payloadOf("/asyncapi/artificial/messages.yaml", "signupReply")
+
+        assertTrue(gene is ObjectGene)
+        //both fields are required here, so neither is wrapped in an optional
+        assertTrue((gene as ObjectGene).fields.all { it !is OptionalGene })
+        assertTrue(field(gene, "request_id") is StringGene)
+        assertTrue(field(gene, "userId") is StringGene)
+    }
+
+    @Test
+    fun testPayloadDeclaredAsAReferenceIsResolved() {
+
+        val schema = AsyncApiAccess.getAsyncApiFromResource("/asyncapi/artificial/messages.yaml")
+        val gene = payloadOf(schema, "signupRequest")
+
+        //the payload is nothing but a $ref, so the gene is named after the schema it points at
+        assertEquals("SignupRequest", gene.name)
+
+        val email = field(gene, "email")
+        assertTrue(email is StringGene, "expected a string, got ${email.javaClass.simpleName}")
+
+        //and the schema that one reaches in turn is resolved too
+        assertTrue(field(gene, "address") is ObjectGene)
+    }
+
+    @Test
+    fun testNumericBoundsAreKept() {
+
+        val schema = AsyncApiAccess.getAsyncApiFromResource("/asyncapi/sut/ncs-kafka.yaml")
+        val gene = payloadOf(schema, "bessjRequest")
+
+        /*
+            This is the whole point of the search for this service: the reply is an error below
+            n = 3, so the bound has to survive into the gene for the boundary to be findable.
+         */
+        val n = field(gene, "n") as IntegerGene
+        assertEquals(3, n.min)
+        assertEquals(1000, n.max)
+    }
+
+    @Test
+    fun testHeadersAreBuiltSeparatelyFromThePayload() {
+
+        val schema = AsyncApiAccess.getAsyncApiFromResource("/asyncapi/artificial/messages.yaml")
+        val message = schema.messages.getValue("signupRequest")
+
+        val headers = AsyncApiGeneBuilder.buildHeadersGene(schema, message, options)!!
+        assertTrue(field(headers, "correlationId") is StringGene)
+
+        //a message declaring no headers gets none, rather than an empty object
+        assertNull(
+            AsyncApiGeneBuilder.buildHeadersGene(schema, schema.messages.getValue("heartbeat"), options)
+        )
+    }
+
+    @Test
+    fun testMessageWithoutAPayload() {
+
+        val schema = AsyncApiAccess.parseFromText(
+            """
+            asyncapi: 3.0.0
+            info:
+              title: A message with nothing in it
+              version: 1.0.0
+            components:
+              messages:
+                empty:
+                  name: Empty
+            """.trimIndent()
+        )
+
+        assertNull(
+            AsyncApiGeneBuilder.buildPayloadGene(schema, schema.messages.getValue("empty"), options)
+        )
+    }
+
+    // ------------------------------------------------------------------ const
+
+    @Test
+    fun testConstBecomesTheSingleValueItPinsTheFieldTo() {
+
+        val gene = payloadOf("/asyncapi/artificial/websocket-reply.yaml", "listLegs")
+
+        /*
+            'request' is declared `const: list_legs`, which is how this document says which
+            message a payload is. The gene builder does not read `const`, so without a rewrite
+            the field would be a free string and the service would not recognise the message.
+         */
+        val request = field(gene, "request")
+        assertTrue(request is EnumGene<*>, "expected an enum, got ${request.javaClass.simpleName}")
+        assertEquals(listOf("list_legs"), (request as EnumGene<*>).values)
+    }
+
+    @Test
+    fun testConstIsPinnedExactlyRatherThanFuzzed() {
+
+        val gene = payloadOf("/asyncapi/artificial/websocket-reply.yaml", "listLegs")
+
+        /*
+            A declared enum normally gains a bogus member on purpose, to probe how a service
+            handles a value it never declared. A discriminator must not: a message carrying one
+            the service does not know is dropped, which would waste half the executions and
+            fire the no-reply fault target for a fault of our own making.
+         */
+        assertFalse((field(gene, "request") as EnumGene<*>).values.any { it.toString() == "EVOMASTER" })
+    }
+
+    @Test
+    fun testConstWithAnExplicitTypeAndConstOfOtherKinds() {
+
+        val schema = AsyncApiAccess.parseFromText(
+            """
+            asyncapi: 3.0.0
+            info:
+              title: Constants of several kinds
+              version: 1.0.0
+            components:
+              messages:
+                m:
+                  payload:
+                    type: object
+                    properties:
+                      typed:
+                        type: string
+                        const: fixed
+                      count:
+                        const: 7
+                      ratio:
+                        const: 1.5
+                      flag:
+                        const: true
+            """.trimIndent()
+        )
+
+        val gene = payloadOf(schema, "m")
+
+        //a const alongside an explicit type is just as invisible to the gene builder as without
+        assertEquals(listOf("fixed"), (field(gene, "typed") as EnumGene<*>).values)
+
+        /*
+            A number is pinned with equal bounds rather than a one-value enum. The builder adds
+            a bogus member to a numeric enum unconditionally, so an enum of one value would
+            always come back as two, and the discriminator would be wrong half the time.
+         */
+        val count = field(gene, "count") as IntegerGene
+        assertEquals(7, count.min)
+        assertEquals(7, count.max)
+
+        val ratio = field(gene, "ratio") as DoubleGene
+        assertEquals(1.5, ratio.min)
+        assertEquals(1.5, ratio.max)
+
+        /*
+            A boolean is the exception, and it is documented rather than fixed: there is no enum
+            handling for booleans and no bounds to set. It matters little in practice, since a
+            two-valued discriminator is guessed half the time anyway.
+         */
+        assertTrue(field(gene, "flag") is BooleanGene)
+    }
+
+    @Test
+    fun testRewritingConstDoesNotTouchTheParsedDocument() {
+
+        val schema = AsyncApiAccess.getAsyncApiFromResource("/asyncapi/artificial/websocket-reply.yaml")
+        val payload = schema.messages.getValue("listLegs").payload!!
+
+        AsyncApiGeneBuilder.buildPayloadGene(schema, schema.messages.getValue("listLegs"), options)
+
+        //the model is shared, so building genes from it must not rewrite it underneath
+        assertTrue(payload.get("properties").get("request").has("const"))
+        assertFalse(payload.get("properties").get("request").has("enum"))
+    }
+
+    // ------------------------------------------------------------------ the harder schemas
+
+    @Test
+    fun testDeclaredEnumsKeepTheirOwnValues() {
+
+        val schema = AsyncApiAccess.parseFromText(
+            """
+            asyncapi: 3.0.0
+            info:
+              title: A genuine enum
+              version: 1.0.0
+            components:
+              messages:
+                m:
+                  payload:
+                    type: object
+                    properties:
+                      kind:
+                        type: string
+                        enum: [ok, error]
+            """.trimIndent()
+        )
+
+        val kind = field(payloadOf(schema, "m"), "kind") as EnumGene<*>
+
+        assertEquals(setOf("ok", "error"), kind.values.map { it.toString() }.toSet())
+    }
+
+    @Test
+    fun testOneOfBecomesAChoice() {
+
+        val schema = AsyncApiAccess.parseFromText(
+            """
+            asyncapi: 3.0.0
+            info:
+              title: A reply that is one of two shapes
+              version: 1.0.0
+            components:
+              messages:
+                m:
+                  payload:
+                    oneOf:
+                      - type: object
+                        properties:
+                          result:
+                            type: integer
+                      - type: object
+                        properties:
+                          error:
+                            type: string
+            """.trimIndent()
+        )
+
+        val gene = payloadOf(schema, "m")
+
+        assertTrue(gene is ChoiceGene<*>, "expected a choice, got ${gene.javaClass.simpleName}")
+        assertEquals(2, (gene as ChoiceGene<*>).getViewOfChildren().size)
+    }
+
+    @Test
+    fun testASchemaThatRefersToItselfTerminates() {
+
+        val schema = AsyncApiAccess.getAsyncApiFromResource("/asyncapi/artificial/reference-cycles.yaml")
+
+        //a tree of nodes is legitimate, and must neither recurse for ever nor be dropped
+        val gene = payloadOf(schema, "request")
+
+        assertTrue(gene is ObjectGene)
+        assertTrue(field(gene, "children") is ArrayGene<*>)
+    }
+
+    // ------------------------------------------------------------------ pointers into a schema
+
+    @Test
+    fun testPayloadPointingAtOnePropertyOfASchema() {
+
+        /*
+            The parser accepts a pointer deeper than the schema it names, checking only that the
+            schema is there. Built naively that becomes the whole schema -- a different message
+            entirely -- because the OpenAPI machinery underneath follows a reference to a whole
+            schema and nothing else.
+         */
+        val schema = AsyncApiAccess.parseFromText(
+            """
+            asyncapi: 3.0.0
+            info:
+              title: A pointer into a schema
+              version: 1.0.0
+            components:
+              messages:
+                m:
+                  payload:
+                    ${'$'}ref: '#/components/schemas/Order/properties/item'
+              schemas:
+                Order:
+                  type: object
+                  properties:
+                    item:
+                      type: string
+                      minLength: 7
+                    quantity:
+                      type: integer
+            """.trimIndent()
+        )
+
+        val gene = payloadOf(schema, "m")
+
+        assertTrue(gene is StringGene, "expected the property, got ${gene.javaClass.simpleName}")
+        assertEquals(7, (gene as StringGene).minLength)
+    }
+
+    @Test
+    fun testPayloadPointingAtAPropertyThatIsNotThere() {
+
+        val schema = AsyncApiAccess.parseFromText(
+            """
+            asyncapi: 3.0.0
+            info:
+              title: A pointer that leads nowhere
+              version: 1.0.0
+            components:
+              messages:
+                m:
+                  payload:
+                    ${'$'}ref: '#/components/schemas/Order/properties/absent'
+              schemas:
+                Order:
+                  type: object
+                  properties:
+                    item:
+                      type: string
+            """.trimIndent()
+        )
+
+        //better to say so than to hand back a message with no fields and no explanation
+        val e = assertThrows(IllegalArgumentException::class.java) {
+            AsyncApiGeneBuilder.buildPayloadGene(schema, schema.messages.getValue("m"), options)
+        }
+
+        assertTrue(e.message!!.contains("absent"), e.message)
+    }
+
+    @Test
+    fun testPayloadReferringToAWholeSchemaStillUsesItsName() {
+
+        //the shortcut that names the gene after the document's own schema must still apply
+        val schema = AsyncApiAccess.getAsyncApiFromResource("/asyncapi/artificial/messages.yaml")
+        val gene = payloadOf(schema, "signupRequest")
+
+        assertEquals("SignupRequest", gene.name)
+    }
+
+    // ------------------------------------------------------------------ where const is not a keyword
+
+    @Test
+    fun testConstIsRewrittenOnlyWhereItIsAKeyword() {
+
+        val schema = AsyncApiAccess.parseFromText(
+            """
+            asyncapi: 3.0.0
+            info:
+              title: The word const in other positions
+              version: 1.0.0
+            components:
+              messages:
+                m:
+                  payload:
+                    type: object
+                    default:
+                      const: this is a value, not a keyword
+                    properties:
+                      const:
+                        type: string
+                        const: still a keyword one level down
+            """.trimIndent()
+        )
+
+        val gene = payloadOf(schema, "m")
+
+        /*
+            A field the document happens to call "const" is still a field, and the const *it*
+            declares is still a keyword. Skipping the word wherever it appears would lose this
+            one, which is why the maps of name-to-schema are walked rather than read as schemas.
+         */
+        assertEquals(
+            listOf("still a keyword one level down"),
+            (field(gene, "const") as EnumGene<*>).values
+        )
+
+        //and the parsed document is never the thing rewritten: it belongs to the parser
+        val payload = schema.messages.getValue("m").payload!!
+        assertTrue(payload.get("default").has("const"))
+        assertFalse(payload.get("properties").get("const").has("enum"))
+    }
+
+    @Test
+    fun testEverySchemaAPayloadCanReachIsAvailable() {
+
+        /*
+            The parser drops any message whose schema reaches a reference it cannot follow, so
+            everything that survives must be buildable. Assert that over a real document rather
+            than trusting it.
+         */
+        val schema = AsyncApiAccess.getAsyncApiFromResource("/asyncapi/sut/ncs-kafka.yaml")
+
+        schema.messages.values.forEach { message ->
+            assertNotNull(
+                AsyncApiGeneBuilder.buildPayloadGene(schema, message, options),
+                "no gene could be built for message '${message.id}'"
+            )
+        }
+    }
+}

--- a/core/src/test/resources/asyncapi/artificial/messages.yaml
+++ b/core/src/test/resources/asyncapi/artificial/messages.yaml
@@ -1,0 +1,62 @@
+asyncapi: 3.0.0
+info:
+  title: The messages of a service, and their schemas
+  version: 1.0.0
+defaultContentType: application/json
+
+components:
+  messageTraits:
+    correlated:
+      correlationId:
+        location: '$message.header#/correlationId'
+      headers:
+        type: object
+        properties:
+          correlationId:
+            type: string
+
+  messages:
+    # payload by reference, correlation and headers inherited from a trait
+    signupRequest:
+      name: SignupRequest
+      title: Sign a user up
+      traits:
+        - $ref: '#/components/messageTraits/correlated'
+      payload:
+        $ref: '#/components/schemas/SignupRequest'
+
+    # payload written inline, and a content type of its own
+    signupReply:
+      name: SignupReply
+      contentType: application/vnd.example+json
+      correlationId:
+        location: '$message.payload#/request_id'
+      payload:
+        type: object
+        required: [request_id, userId]
+        properties:
+          request_id:
+            type: string
+          userId:
+            type: string
+
+    # no name of its own, so it is known by its component key
+    heartbeat:
+      payload:
+        type: object
+
+  schemas:
+    SignupRequest:
+      type: object
+      required: [email]
+      properties:
+        email:
+          type: string
+          format: email
+        address:
+          $ref: '#/components/schemas/Address'
+    Address:
+      type: object
+      properties:
+        city:
+          type: string

--- a/core/src/test/resources/asyncapi/artificial/reference-cycles.yaml
+++ b/core/src/test/resources/asyncapi/artificial/reference-cycles.yaml
@@ -1,0 +1,42 @@
+asyncapi: 3.0.0
+info:
+  title: References that go round in circles
+  version: 1.0.0
+
+# Generators do emit these, and following one for ever would take down the whole run rather
+# than cost the one element it affects.
+
+components:
+  messages:
+    # a message that only points at another message, which points back
+    ping:
+      $ref: '#/components/messages/pong'
+    pong:
+      $ref: '#/components/messages/ping'
+    itself:
+      $ref: '#/components/messages/itself'
+
+    request:
+      name: Request
+      correlationId:
+        $ref: '#/components/correlationIds/first'
+      payload:
+        $ref: '#/components/schemas/Node'
+
+  correlationIds:
+    first:
+      $ref: '#/components/correlationIds/second'
+    second:
+      $ref: '#/components/correlationIds/first'
+
+  schemas:
+    # a schema referring to itself is perfectly legitimate: a tree of nodes
+    Node:
+      type: object
+      properties:
+        value:
+          type: string
+        children:
+          type: array
+          items:
+            $ref: '#/components/schemas/Node'

--- a/core/src/test/resources/asyncapi/artificial/websocket-reply.yaml
+++ b/core/src/test/resources/asyncapi/artificial/websocket-reply.yaml
@@ -1,0 +1,124 @@
+asyncapi: 3.0.0
+info:
+  title: A duplex socket carrying many messages
+  version: 1.0.0
+defaultContentType: application/json
+
+servers:
+  socket:
+    host: localhost:8088
+    protocol: ws
+    pathname: /v1/vsi
+
+channels:
+  vsi:
+    address: /v1/vsi
+    messages:
+      list_legs:
+        $ref: '#/components/messages/listLegs'
+      list_legs.result:
+        $ref: '#/components/messages/listLegsResult'
+      get_leg:
+        $ref: '#/components/messages/getLeg'
+      get_leg.result:
+        $ref: '#/components/messages/getLegResult'
+      error:
+        $ref: '#/components/messages/error'
+    bindings:
+      ws:
+        method: GET
+
+operations:
+  recv_list_legs:
+    action: receive
+    summary: List all active legs
+    channel:
+      $ref: '#/channels/vsi'
+    messages:
+      - $ref: '#/channels/vsi/messages/list_legs'
+    reply:
+      channel:
+        $ref: '#/channels/vsi'
+      messages:
+        - $ref: '#/channels/vsi/messages/list_legs.result'
+        - $ref: '#/channels/vsi/messages/error'
+
+  recv_get_leg:
+    action: receive
+    summary: Get a single leg
+    channel:
+      $ref: '#/channels/vsi'
+    messages:
+      - $ref: '#/channels/vsi/messages/get_leg'
+    reply:
+      channel:
+        $ref: '#/channels/vsi'
+      messages:
+        - $ref: '#/channels/vsi/messages/get_leg.result'
+        - $ref: '#/channels/vsi/messages/error'
+
+components:
+  messages:
+    listLegs:
+      name: ListLegs
+      correlationId:
+        location: '$message.payload#/request_id'
+      payload:
+        type: object
+        required: [request, request_id]
+        properties:
+          request:
+            const: list_legs
+          request_id:
+            type: string
+    listLegsResult:
+      name: ListLegsResult
+      correlationId:
+        location: '$message.payload#/request_id'
+      payload:
+        type: object
+        properties:
+          request_id:
+            type: string
+          legs:
+            type: array
+            items:
+              type: string
+    getLeg:
+      name: GetLeg
+      correlationId:
+        location: '$message.payload#/request_id'
+      payload:
+        type: object
+        required: [request, request_id, leg_id]
+        properties:
+          request:
+            const: get_leg
+          request_id:
+            type: string
+          leg_id:
+            type: string
+    getLegResult:
+      name: GetLegResult
+      payload:
+        type: object
+        properties:
+          request_id:
+            type: string
+          leg:
+            type: [object, "null"]
+    error:
+      name: Error
+      payload:
+        type: object
+        required: [error]
+        properties:
+          request_id:
+            type: string
+          error:
+            type: object
+            properties:
+              code:
+                type: integer
+              message:
+                type: string

--- a/core/src/test/resources/asyncapi/sut/ncs-kafka.yaml
+++ b/core/src/test/resources/asyncapi/sut/ncs-kafka.yaml
@@ -1,0 +1,288 @@
+# The NCS numerical service, re-expressed as an event-driven API over Kafka.
+# Written for EvoMaster; not taken from a third party.
+asyncapi: 3.0.0
+info:
+  title: NCS over Kafka
+  version: 1.0.0
+  description: |
+    Request/reply model of the **NCS** (Numerical Case Study) SUT from the EvoMaster
+    Dataset (`jdk_8_maven/cs/rest/artificial/ncs`), re-expressed as an event-driven API
+    over **Kafka**.
+
+    NCS is a stateless numerical service: each operation takes a few numbers and returns a
+    computed result. The six original REST endpoints map one-to-one to request/reply
+    operations here — a client publishes a request on the operation's request topic, and the
+    service (the SUT) replies on the operation's reply topic. Error replies mirror the REST
+    4xx responses (e.g. an out-of-range argument).
+
+    Correlation between a request and its reply travels in a **Kafka message header**
+    (`correlationId`).
+defaultContentType: application/json
+
+servers:
+  kafka:
+    host: localhost:9092
+    protocol: kafka
+    description: Kafka broker carrying the NCS request and reply topics.
+
+channels:
+  triangleRequest:
+    address: ncs.triangle.request
+    messages:
+      triangleRequest:
+        $ref: '#/components/messages/triangleRequest'
+  triangleReply:
+    address: ncs.triangle.reply
+    messages:
+      result:
+        $ref: '#/components/messages/intResult'
+
+  bessjRequest:
+    address: ncs.bessj.request
+    messages:
+      bessjRequest:
+        $ref: '#/components/messages/bessjRequest'
+  bessjReply:
+    address: ncs.bessj.reply
+    messages:
+      result:
+        $ref: '#/components/messages/doubleResult'
+      error:
+        $ref: '#/components/messages/error'
+
+  expintRequest:
+    address: ncs.expint.request
+    messages:
+      expintRequest:
+        $ref: '#/components/messages/expintRequest'
+  expintReply:
+    address: ncs.expint.reply
+    messages:
+      result:
+        $ref: '#/components/messages/doubleResult'
+      error:
+        $ref: '#/components/messages/error'
+
+  fisherRequest:
+    address: ncs.fisher.request
+    messages:
+      fisherRequest:
+        $ref: '#/components/messages/fisherRequest'
+  fisherReply:
+    address: ncs.fisher.reply
+    messages:
+      result:
+        $ref: '#/components/messages/doubleResult'
+      error:
+        $ref: '#/components/messages/error'
+
+  gammqRequest:
+    address: ncs.gammq.request
+    messages:
+      gammqRequest:
+        $ref: '#/components/messages/gammqRequest'
+  gammqReply:
+    address: ncs.gammq.reply
+    messages:
+      result:
+        $ref: '#/components/messages/doubleResult'
+      error:
+        $ref: '#/components/messages/error'
+
+  remainderRequest:
+    address: ncs.remainder.request
+    messages:
+      remainderRequest:
+        $ref: '#/components/messages/remainderRequest'
+  remainderReply:
+    address: ncs.remainder.reply
+    messages:
+      result:
+        $ref: '#/components/messages/intResult'
+      error:
+        $ref: '#/components/messages/error'
+
+operations:
+  checkTriangle:
+    action: receive
+    summary: Classify a triangle from three integer edges (REST GET /api/triangle/{a}/{b}/{c}).
+    channel:
+      $ref: '#/channels/triangleRequest'
+    reply:
+      channel:
+        $ref: '#/channels/triangleReply'
+  bessj:
+    action: receive
+    summary: Bessel function J_n(x) (REST GET /api/bessj/{n}/{x}).
+    channel:
+      $ref: '#/channels/bessjRequest'
+    reply:
+      channel:
+        $ref: '#/channels/bessjReply'
+  expint:
+    action: receive
+    summary: Exponential integral E_n(x) (REST GET /api/expint/{n}/{x}).
+    channel:
+      $ref: '#/channels/expintRequest'
+    reply:
+      channel:
+        $ref: '#/channels/expintReply'
+  fisher:
+    action: receive
+    summary: Fisher F-distribution value (REST GET /api/fisher/{m}/{n}/{x}).
+    channel:
+      $ref: '#/channels/fisherRequest'
+    reply:
+      channel:
+        $ref: '#/channels/fisherReply'
+  gammq:
+    action: receive
+    summary: Incomplete gamma function Q(a, x) (REST GET /api/gammq/{a}/{x}).
+    channel:
+      $ref: '#/channels/gammqRequest'
+    reply:
+      channel:
+        $ref: '#/channels/gammqReply'
+  remainder:
+    action: receive
+    summary: Integer remainder of a / b (REST GET /api/remainder/{a}/{b}).
+    channel:
+      $ref: '#/channels/remainderRequest'
+    reply:
+      channel:
+        $ref: '#/channels/remainderReply'
+
+components:
+  messages:
+    triangleRequest:
+      name: TriangleRequest
+      title: Triangle classification request
+      contentType: application/json
+      correlationId:
+        location: '$message.header#/correlationId'
+      payload:
+        $ref: '#/components/schemas/TriangleRequest'
+    bessjRequest:
+      name: BessjRequest
+      contentType: application/json
+      correlationId:
+        location: '$message.header#/correlationId'
+      payload:
+        $ref: '#/components/schemas/BessjRequest'
+    expintRequest:
+      name: ExpintRequest
+      contentType: application/json
+      correlationId:
+        location: '$message.header#/correlationId'
+      payload:
+        $ref: '#/components/schemas/ExpintRequest'
+    fisherRequest:
+      name: FisherRequest
+      contentType: application/json
+      correlationId:
+        location: '$message.header#/correlationId'
+      payload:
+        $ref: '#/components/schemas/FisherRequest'
+    gammqRequest:
+      name: GammqRequest
+      contentType: application/json
+      correlationId:
+        location: '$message.header#/correlationId'
+      payload:
+        $ref: '#/components/schemas/GammqRequest'
+    remainderRequest:
+      name: RemainderRequest
+      contentType: application/json
+      correlationId:
+        location: '$message.header#/correlationId'
+      payload:
+        $ref: '#/components/schemas/RemainderRequest'
+    intResult:
+      name: IntResult
+      title: Integer result reply (Dto.resultAsInt)
+      contentType: application/json
+      correlationId:
+        location: '$message.header#/correlationId'
+      payload:
+        $ref: '#/components/schemas/IntResult'
+    doubleResult:
+      name: DoubleResult
+      title: Floating-point result reply (Dto.resultAsDouble)
+      contentType: application/json
+      correlationId:
+        location: '$message.header#/correlationId'
+      payload:
+        $ref: '#/components/schemas/DoubleResult'
+    error:
+      name: Error
+      title: Error reply (mirrors a REST 4xx response)
+      contentType: application/json
+      correlationId:
+        location: '$message.header#/correlationId'
+      payload:
+        $ref: '#/components/schemas/Error'
+
+  schemas:
+    TriangleRequest:
+      type: object
+      required: [a, b, c]
+      properties:
+        a: { type: integer, format: int32, description: First edge }
+        b: { type: integer, format: int32, description: Second edge }
+        c: { type: integer, format: int32, description: Third edge }
+    BessjRequest:
+      type: object
+      required: [n, x]
+      properties:
+        n:
+          type: integer
+          format: int32
+          minimum: 3
+          maximum: 1000
+          description: Order; the service replies with an error outside 3..1000.
+        x: { type: number, format: double }
+    ExpintRequest:
+      type: object
+      required: [n, x]
+      properties:
+        n: { type: integer, format: int32, minimum: 0 }
+        x: { type: number, format: double, description: x >= 0; the service errors otherwise. }
+    FisherRequest:
+      type: object
+      required: [m, n, x]
+      properties:
+        m: { type: integer, format: int32, minimum: 1, maximum: 1000 }
+        n: { type: integer, format: int32, minimum: 1, maximum: 1000 }
+        x: { type: number, format: double }
+    GammqRequest:
+      type: object
+      required: [a, x]
+      properties:
+        a: { type: number, format: double, description: a > 0; the service errors otherwise. }
+        x: { type: number, format: double, description: x >= 0. }
+    RemainderRequest:
+      type: object
+      required: [a, b]
+      properties:
+        a: { type: integer, format: int32, minimum: -10000, maximum: 10000 }
+        b: { type: integer, format: int32, minimum: -10000, maximum: 10000 }
+    IntResult:
+      type: object
+      required: [resultAsInt]
+      properties:
+        resultAsInt: { type: integer, format: int32 }
+    DoubleResult:
+      type: object
+      required: [resultAsDouble]
+      properties:
+        resultAsDouble: { type: number, format: double }
+    Error:
+      type: object
+      required: [error]
+      properties:
+        error:
+          type: object
+          required: [code, message]
+          properties:
+            code: { type: integer, description: 'Mirrors the REST status (e.g. 400).' }
+            message: { type: string }


### PR DESCRIPTION
Seventh in the AsyncAPI stack, on top of #5. The first piece that turns the parsed document into something the search can hold.

## The seam

The parser deliberately stops at the schema: it leaves every `$ref` inside a payload alone, and guarantees that whatever those references reach is present in `componentSchemas`. This trades on that guarantee — it hands the whole schema map to `RestActionBuilderV3.createGeneForDTO`, which wraps it in a synthetic OpenAPI document and lets the existing machinery resolve the references and build the genes.

Reusing that rather than writing a second JSON-Schema-to-gene converter means AsyncAPI payloads get what REST already has. I checked rather than assumed, by characterising the seam against the shapes AsyncAPI actually uses before writing anything:

| shape | result |
|---|---|
| object with `required` | required fields plain, others `OptionalGene` |
| `$ref` to a component schema | resolved and inlined |
| `minimum` / `maximum` | **kept** — `IntegerGene [min=3, max=1000]` |
| `oneOf` | `ChoiceGene` over both branches |
| self-referencing schema | terminates via `CycleObjectGene` |
| `nullable: true` | `NullableGene` |
| `type: [object, "null"]` | object read correctly, but nullability dropped |
| `const` | **lost** — becomes a free string |

The bounds one matters most: NCS's error reply is only reachable because `n` is declared `minimum: 3`, so the boundary has to survive into the gene for the search to find it. It does.

## `const`

`const` is invisible to the gene builder, with or without an explicit `type` beside it. That is not an exotic corner: `const` is how a document says *which message* a payload is (`request: {const: list_legs}` — voiceblender does this across 109 operations, and five documents in the wider corpus use it). Left alone, the discriminator is a random string and the service never recognises the message.

It is rewritten to the single-valued `enum` that means the same thing, with the type inferred from the literal when the schema states none. A boolean `const` is the exception and stays free, since there is no enum handling for booleans — asserted in a test rather than left to be discovered.

## Why `invalidData` is off for payloads

That flag adds a bogus member to every enum on purpose, to probe how a service handles a value it never declared. In a message payload it backfires: a `const` arrives here as a one-value enum, and a message carrying an unrecognised discriminator is silently dropped. Half the messages sent would go nowhere — wasting executions, and firing the no-reply fault target for a fault of our own making.

Nothing is lost for reaching error paths, since the bounds that drive them are preserved.

## One change to shared REST code

Finding the above exposed an inconsistency, fixed here. The bogus member added to a **string** enum is guarded by `options.invalidData`:

```kotlin
if (options.invalidData) { add("EVOMASTER") }
```

but the `42`, `42L` and `42.0` added to **integer, long and number** enums were not — they were added even with invalid data switched off. They are now guarded the same way. Since `allowInvalidData` defaults to `true`, default behaviour is unchanged; this only takes effect for a caller that explicitly asks for valid data, which is what this PR does.

Happy to split that into its own PR if you would rather.

## Testing

13 new tests in `AsyncApiGeneBuilderTest`, including one that builds a gene for every message of a real document and one that asserts building genes does not rewrite the parsed model underneath. 344 in total across the AsyncAPI package and the REST suites that exercise the shared builder — `RestActionBuilderV3Test` (155), `HttpSemanticsOracleTest` (55), `SchemaUtilsTest`, `RestSchemaOraclesTest`, `BlackBoxUtilsTest`, `JsonPatchSchemaResolverTest`.

