### PR TITLE
Fix escaping response assertion field paths in generated JVM tests

### DIFF
--- a/core/src/main/kotlin/org/evomaster/core/output/service/ApiTestCaseWriter.kt
+++ b/core/src/main/kotlin/org/evomaster/core/output/service/ApiTestCaseWriter.kt
@@ -306,22 +306,23 @@ abstract class ApiTestCaseWriter : TestCaseWriter() {
 
                     var needsDot = true
 
-                    val fieldName = if (format.isJava()) {
-                        "'${it.key}'"
-                    } else if (format.isKotlin()){
-                        "'${handleDollarSign(it.key)}'"
+                    val fieldName = if (format.isJavaOrKotlin()) {
+                        "'${escapeJvmGPathFieldName(it.key)}'"
                     } else if (format.isJavaScript()) {
                         //field name could have any character... need to use [] notation then
                         if (it.key.matches(Regex("^[a-zA-Z][a-zA-Z0-9]*$"))) {
                             it.key
                         } else {
                             needsDot = false
-                            "[\"${it.key}\"]"
+                            "[\"${escapeFieldNameForStringLiteral(it.key)}\"]"
                         }
                     } else if (format.isPython()) {
                         needsDot = false
-                        "[\"${it.key}\"]"
-                    //TODO need to deal with '' C#? see EscapeRest
+                        "[\"${escapeFieldNameForStringLiteral(it.key)}\"]"
+                    // C# is no longer a supported output format, but keep the legacy branch safe.
+                    } else if (format.isCsharp()) {
+                        needsDot = false
+                        "[\"${escapeFieldNameForStringLiteral(it.key)}\"]"
                     } else {
                         it.key
                     }
@@ -342,12 +343,34 @@ abstract class ApiTestCaseWriter : TestCaseWriter() {
                     }
                 }
     }
+
     /*
-        a quick fix on handling dollar sign in assertion
-        TODO, might move to other places to systematically handle the assertions with special symbols
+        RestAssured evaluates a field path as Groovy source after Java/Kotlin has evaluated the
+        generated string literal. Escape for both layers so that, for example, a JSON key named
+        \g is emitted as '\\\\g' in the GPath expression inside the generated JVM source.
      */
-    private fun handleDollarSign(text: String): String{
-        return text.replace("\$", "\\\$")
+    private fun escapeJvmGPathFieldName(text: String): String {
+        val escapedForGroovySingleQuotedString = text
+            .replace("\\", "\\\\")
+            .replace("'", "\\'")
+            .replace("\n", "\\n")
+            .replace("\r", "\\r")
+            .replace("\b", "\\b")
+            .replace("\t", "\\t")
+
+        return GeneUtils.applyEscapes(
+            escapedForGroovySingleQuotedString,
+            mode = GeneUtils.EscapeMode.ASSERTION,
+            format = format
+        )
+    }
+
+    private fun escapeFieldNameForStringLiteral(text: String): String {
+        return GeneUtils.applyEscapes(
+            text,
+            mode = GeneUtils.EscapeMode.ASSERTION,
+            format = format
+        )
     }
     /**
      * Formats a field path according to the active output format.

--- a/core/src/test/kotlin/org/evomaster/core/output/TestCaseWriterTest.kt
+++ b/core/src/test/kotlin/org/evomaster/core/output/TestCaseWriterTest.kt
@@ -1,5 +1,6 @@
 package org.evomaster.core.output
 
+import io.restassured.path.json.JsonPath
 import org.evomaster.client.java.controller.api.dto.database.schema.DatabaseType
 import org.evomaster.core.EMConfig
 import org.evomaster.core.TestUtils
@@ -143,6 +144,92 @@ class TestCaseWriterTest : WriterTestBase(){
 
         assertTrue(lines.toString().contains("containsString(\"Unable to obtain a new access token for resource\")"))
         assertFalse(lines.toString().contains("&#39"))
+    }
+
+    @Test
+    fun testJvmResponseAssertionEscapesBackslashForSourceAndGPath() {
+        val body = """{"\\g":{"name":"disabled"}}"""
+
+        listOf(OutputFormat.JAVA_JUNIT_5, OutputFormat.KOTLIN_JUNIT_5).forEach { format ->
+            val output = generateJsonResponseAssertions(format, body)
+
+            assertTrue(
+                output.contains(".body(\"'\\\\\\\\g'.'name'\", containsString(\"disabled\"))"),
+                "Expected a backslash escaped for both the JVM source and Groovy GPath in $format, got:\n$output"
+            )
+            assertFalse(
+                output.contains(".body(\"'\\g'.'name'\""),
+                "An unescaped backslash would make the generated JVM test invalid in $format"
+            )
+        }
+    }
+
+    @Test
+    fun testJvmResponseAssertionGPathResolvesBackslashAndSingleQuoteKeys() {
+        val body = """{"\\g":{"single'quote":"disabled"}}"""
+        val pathAsGroovySource = "'\\\\g'.'single\\'quote'"
+
+        assertEquals("disabled", JsonPath.from(body).getString(pathAsGroovySource))
+
+        listOf(OutputFormat.JAVA_JUNIT_5, OutputFormat.KOTLIN_JUNIT_5).forEach { format ->
+            val output = generateJsonResponseAssertions(format, body)
+
+            assertTrue(
+                output.contains(".body(\"'\\\\\\\\g'.'single\\\\'quote'\", containsString(\"disabled\"))"),
+                "Expected field names to be escaped for both JVM source and Groovy GPath in $format, got:\n$output"
+            )
+        }
+    }
+
+    @Test
+    fun testKotlinResponseAssertionStillEscapesDollarInFieldName() {
+        val output = generateJsonResponseAssertions(
+            OutputFormat.KOTLIN_JUNIT_5,
+            """{"dollar${'$'}key":"value"}"""
+        )
+
+        assertTrue(
+            output.contains(".body(\"'dollar\\\$key'\", containsString(\"value\"))"),
+            "Expected the dollar sign to remain escaped in generated Kotlin, got:\n$output"
+        )
+    }
+
+    @Test
+    fun testNonJvmResponseAssertionsEscapeBackslashInBracketAccess() {
+        val body = """{"\\g":{"name":"disabled"}}"""
+
+        val javaScriptOutput = generateJsonResponseAssertions(OutputFormat.JS_JEST, body)
+        assertTrue(
+            javaScriptOutput.contains("expect(res_0.body[\"\\\\g\"].name).toBe(\"disabled\");"),
+            "Expected a JavaScript string-safe bracket access, got:\n$javaScriptOutput"
+        )
+
+        val pythonOutput = generateJsonResponseAssertions(OutputFormat.PYTHON_UNITTEST, body)
+        assertTrue(
+            pythonOutput.contains("assert res_0.json()[\"\\\\g\"][\"name\"] == \"disabled\""),
+            "Expected a Python string-safe bracket access, got:\n$pythonOutput"
+        )
+    }
+
+    private fun generateJsonResponseAssertions(format: OutputFormat, body: String): String {
+        val action = RestCallAction("1", HttpVerb.GET, RestPath("/foo"), mutableListOf())
+        val (_, baseUrlOfSut, evaluatedIndividual) = buildResourceEvaluatedIndividual(
+            dbInitialization = mutableListOf(),
+            groups = mutableListOf(mutableListOf<SqlAction>() to mutableListOf(action)),
+            format = format
+        )
+
+        val result = evaluatedIndividual.seeResult(action.getLocalId()) as RestCallResult
+        result.setTimedout(false)
+        result.setStatusCode(200)
+        result.setBody(body)
+        result.setBodyType(MediaType.APPLICATION_JSON_TYPE)
+
+        val writer = RestTestCaseWriter(getConfig(format), PartialOracles())
+        return writer.convertToCompilableTestCode(
+            TestCase(test = evaluatedIndividual, name = "test"),
+            baseUrlOfSut
+        ).toString()
     }
 
 


### PR DESCRIPTION
## Summary

This PR fixes escaping of response assertion field paths when EvoMaster generates Java or Kotlin tests.

A response field name is embedded in two different syntactic layers: first as a single-quoted Groovy GPath segment used by RestAssured, and then as a Java/Kotlin string literal. Characters such as a backslash or a single quote must therefore be escaped for both layers, in the correct order.

## Problem observed in real experiments

We found the issue while repeatedly generating and executing tests for `tiltaksgjennomforing`.

Two concrete generated field paths caused deterministic failures:

1. A response field containing a backslash generated:

   ```java
   .body("'\g'.'name'", containsString("disabled"));
   ```

   The raw backslash reached the generated Java source and produced an `illegal escape character` compilation error.

2. A response field containing a single quote, such as the value below:

   ```text
   <img src=x onerror=alert('XSS')>
   ```

   generated:

   ```java
   .body("'<img src=x onerror=alert('XSS')>'", equalTo(false));
   ```

   The inner quote prematurely closed the Groovy GPath field segment. RestAssured then parsed the remaining text as a Groovy expression, which led to errors such as an undefined `XSS` parameter or `MissingPropertyException`.

These failures were reproducible across repeated executions because the generated source itself was invalid; they were not caused by instability in the system under test.

## Root cause

The previous implementation inserted field names into a single-quoted GPath segment and only applied the escaping needed by the generated JVM source.

That handles one layer, but not both:

1. the field name must first be escaped as content inside a single-quoted Groovy GPath segment;
2. the resulting GPath must then be escaped as content inside a Java/Kotlin string literal.

If the first step is skipped, a quote changes the GPath structure and a backslash may be interpreted by either Groovy or the JVM compiler before it reaches RestAssured.

## Changes

This PR adds a dedicated escaping path for response assertion field names:

- escape backslashes and single quotes for the single-quoted Groovy GPath segment;
- apply `GeneUtils.applyEscapes` afterwards so the already escaped GPath is represented correctly in generated Java/Kotlin source;
- use the same handling for both Java and Kotlin output;
- add regression coverage for ordinary names, quotes, backslashes, and combinations of both characters.

For example, the generated assertion for the XSS-shaped field becomes:

```java
.body("'<img src=x onerror=alert(\\'XSS\\')>'", equalTo(false));
```

and backslashes are preserved as literal field-name characters instead of becoming invalid JVM escapes.

## Validation

### Unit/regression tests

The focused `TestCaseWriterTest` suite passes after rebasing onto the current upstream `master`:

- 41 tests run
- 0 failures
- 0 errors

### End-to-end validation

We also rebuilt EvoMaster with this change and ran a targeted validation against `tiltaksgjennomforing` using response paths that previously triggered both failure modes.

Results:

- 10 independently generated logical test suites
- 20 JUnit XML result files
- 3,806 executed tests
- 3,806 passed
- 0 failures
- 0 errors
- 0 skipped tests
- all 10 suite runs completed with exit code 0

The corrected generated tests contained three field paths with embedded single quotes and three with backslashes. None of the earlier `illegal escape character`, undefined `XSS` parameter, or `MissingPropertyException` signatures appeared.