### PR TITLE
Fix for unhandled exception on RegexGene.randomize

### DIFF
--- a/core/src/main/kotlin/org/evomaster/core/search/gene/regex/RegexGene.kt
+++ b/core/src/main/kotlin/org/evomaster/core/search/gene/regex/RegexGene.kt
@@ -13,6 +13,7 @@ import org.evomaster.core.search.service.mutator.genemutation.AdditionalGeneMuta
 import org.evomaster.core.search.service.mutator.genemutation.SubsetGeneMutationSelectionStrategy
 import org.evomaster.core.utils.RegexFlags
 import org.evomaster.core.utils.RegexWithExternalFlags
+import org.slf4j.LoggerFactory
 import java.util.regex.Pattern
 
 /**
@@ -42,6 +43,8 @@ class RegexGene(
 ) : CompositeFixedGene(name, disjunctions) {
 
     companion object {
+        private val log = LoggerFactory.getLogger(RegexGene::class.java)
+
         private val patternCache = java.util.concurrent.ConcurrentHashMap<RegexWithExternalFlags, Pattern>()
 
         private fun compiledPattern(sourceRegex: String, flags: RegexFlags): Pattern {
@@ -95,7 +98,11 @@ class RegexGene(
             }
         }
 
-        throw IllegalStateException("Could not repair regex value")
+        // failed to repair regex, the value of this gene does not match the source regex.
+        // this may happen because regex is unsatisfiable, regex bug or because of EMs limited support of regex assertions.
+        val message = "Could not repair value for regex: \"$sourceRegex\", last tried: \"${getValueAsRawString()}\""
+        log.warn(message)
+        assert(false) { message }
     }
 
     @Deprecated("Do not call directly outside this package. Call setFromStringValue")

--- a/core/src/test/kotlin/org/evomaster/core/parser/GeneRegexJavaVisitorTest.kt
+++ b/core/src/test/kotlin/org/evomaster/core/parser/GeneRegexJavaVisitorTest.kt
@@ -476,11 +476,11 @@ class GeneRegexJavaVisitorTest : GeneRegexEcma262VisitorTest() {
 
     @Test
     fun testUnsatisfiableLookaheads() {
-        assertThrows<IllegalStateException> { checkSameAsJava("(?=.*\\d)(?=.*[A-Z])[a-zA-Z]{4,8}") }
-        assertThrows<IllegalStateException> { checkSameAsJava("(?=.*\\d)(?=.*[A-Z])") }
-        assertThrows<IllegalStateException> { checkSameAsJava("(?=.*\\d)[a-z]+") }
-        assertThrows<IllegalStateException> { checkSameAsJava("(?=bbbX)aaa[a-z]") }
-        assertThrows<IllegalStateException> { checkSameAsJava("(?=abcde)a(bcef|de)de") }
+        assertThrows<AssertionError> { checkSameAsJava("(?=.*\\d)(?=.*[A-Z])[a-zA-Z]{4,8}") }
+        assertThrows<AssertionError> { checkSameAsJava("(?=.*\\d)(?=.*[A-Z])") }
+        assertThrows<AssertionError> { checkSameAsJava("(?=.*\\d)[a-z]+") }
+        assertThrows<AssertionError> { checkSameAsJava("(?=bbbX)aaa[a-z]") }
+        assertThrows<AssertionError> { checkSameAsJava("(?=abcde)a(bcef|de)de") }
         assertThrows<IllegalStateException> { checkSameAsJava("(?=[a&&b])a(bcef|de)de") }
         checkSameAsJava("abc|(?=[a&&b])def")
     }
@@ -505,7 +505,7 @@ class GeneRegexJavaVisitorTest : GeneRegexEcma262VisitorTest() {
 
     @Test
     fun testUnsatisfiableLookbehinds() {
-        assertThrows<IllegalStateException> { checkSameAsJava("(?<=X)a") }
+        assertThrows<AssertionError> { checkSameAsJava("(?<=X)a") }
         assertThrows<IllegalStateException> { checkSameAsJava("a(?<=[a&&b])a") }
     }
 
@@ -521,7 +521,7 @@ class GeneRegexJavaVisitorTest : GeneRegexEcma262VisitorTest() {
     fun testNestedAssertionOutwardEscape() {
         checkSameAsJava("""^a((?=b\d)b)\d$""")
         checkSameAsJava("""^\d(x(?<=\dx))y$""")
-        assertThrows<IllegalStateException> { checkSameAsJava("""^a((?=b\d)b)y$""") }
-        assertThrows<IllegalStateException> { checkSameAsJava("^(a(?=bc)d)e$") }
+        assertThrows<AssertionError> { checkSameAsJava("""^a((?=b\d)b)y$""") }
+        assertThrows<AssertionError> { checkSameAsJava("^(a(?=bc)d)e$") }
     }
 }


### PR DESCRIPTION
Replaced `RegexGene.randomize(...)`'s `throw IllegalStateException(...)` for a `log.warn(...)` and an `assert(...)` both with more descriptive messages. Updated tests that relied on this Exception.
Makes EM stop crashing on a regex gene value mismatch, will now log mismatches instead.
Investigating mismatch cause further.
Sorry for the inconvenience and the delay! Had some issues setting up WFD to verify this.