### PR TITLE
Fix $all heuristic to quantify over the expected values

### DIFF
--- a/client-java/controller/src/main/java/org/evomaster/client/java/controller/mongo/MongoHeuristicsCalculator.java
+++ b/client-java/controller/src/main/java/org/evomaster/client/java/controller/mongo/MongoHeuristicsCalculator.java
@@ -532,6 +532,17 @@ public class MongoHeuristicsCalculator {
         }
     }
 
+    /**
+     * Computes the heuristic score for a {"f",{"$all": [v1, ..., vn] }} query.
+     * The condition holds when the array held by "f" contains every one of the expected values,
+     * so the score is an AND aggregation over the expected values, each of which is scored by an
+     * OR aggregation over the elements of the array. Note the direction: extra elements in the
+     * document are irrelevant, whereas a missing expected value makes the condition false.
+     *
+     * @param operation the {"f",{"$all": [...]}} query encapsulated as an AllOperation
+     * @param document  the BSON document to evaluate the heuristic score against
+     * @return a Truthness object representing the distance of the document from meeting the condition
+     */
     private Truthness computeHeuristic(AllOperation<?> operation, Object document) {
         requireNonNullQueryAndDocument(operation, document);
 
@@ -550,15 +561,32 @@ public class MongoHeuristicsCalculator {
                 if (actualValuesList.isEmpty()) {
                     return C_FALSE;
                 } else {
-                    Truthness res = buildAndAggregationTruthness(actualValuesList
+                    Truthness res = buildAndAggregationTruthness(expectedValues
                             .stream()
-                            .map(actualValuesListElement ->
-                                    computeHeuristic(actualValuesListElement, expectedValues))
+                            .map(expectedValue ->
+                                    computeHeuristicForContainedValue(expectedValue, actualValuesList))
                             .toArray(Truthness[]::new));
                     return buildSafeScaledTruthness(res);
                 }
             }
         }
+    }
+
+    /**
+     * Computes the heuristic score for the presence of a single expected value inside the array
+     * held by the queried field, ie an OR aggregation over the elements of that array.
+     *
+     * @param expectedValue a value that a {"f",{"$all": [...]}} query requires to be present
+     * @param actualValues  the non-empty array held by the field "f" in the document
+     * @return a Truthness object representing how close the array is to containing the expected value
+     */
+    private Truthness computeHeuristicForContainedValue(Object expectedValue, List<?> actualValues) {
+        Objects.requireNonNull(actualValues);
+
+        return buildOrAggregationTruthness(actualValues.stream()
+                .map(actualValue -> computeHeuristicComparisonNullableValues(expectedValue, actualValue,
+                        SqlExpressionEvaluator.ComparisonOperatorType.EQUALS_TO))
+                .toArray(Truthness[]::new));
     }
 
     private static Truthness buildSafeScaledTruthness(Truthness truthness) {

--- a/client-java/controller/src/test/java/org/evomaster/client/java/controller/mongo/MongoHeuristicsCalculatorTest.java
+++ b/client-java/controller/src/test/java/org/evomaster/client/java/controller/mongo/MongoHeuristicsCalculatorTest.java
@@ -273,6 +273,40 @@ public class MongoHeuristicsCalculatorTest {
         assertTrue(calculator.computeHeuristicDocument(convertToDocument(allQuery), document).isFalse());
     }
 
+    @Test
+    public void testAllMatchesWhenDocumentArrayHasExtraElements() {
+        // $all only requires the expected values to be present; extra elements are irrelevant
+        Document doc = new Document().append("employees", new ArrayList<>(Arrays.asList(1, 5, 6)));
+        Bson allQuery = Filters.all("employees", new ArrayList<>(Arrays.asList(1, 5)));
+        MongoHeuristicsCalculator calculator = new MongoHeuristicsCalculator();
+        assertTrue(calculator.computeHeuristicDocument(convertToDocument(allQuery), doc).isTrue());
+    }
+
+    @Test
+    public void testAllDoesNotMatchWhenAnExpectedValueIsMissing() {
+        // the array contains 1, but not 2 nor 3, so the condition does not hold
+        Document doc = new Document().append("employees", new ArrayList<>(Arrays.asList(1)));
+        Bson allQuery = Filters.all("employees", new ArrayList<>(Arrays.asList(1, 2, 3)));
+        MongoHeuristicsCalculator calculator = new MongoHeuristicsCalculator();
+        assertTrue(calculator.computeHeuristicDocument(convertToDocument(allQuery), doc).isFalse());
+    }
+
+    @Test
+    public void testAllGivesBetterScoreWhenFewerExpectedValuesAreMissing() {
+        Bson allQuery = Filters.all("employees", new ArrayList<>(Arrays.asList(1, 2, 3)));
+        Document closer = new Document().append("employees", new ArrayList<>(Arrays.asList(1, 2)));
+        Document farther = new Document().append("employees", new ArrayList<>(Arrays.asList(1)));
+
+        MongoHeuristicsCalculator calculator = new MongoHeuristicsCalculator();
+        Truthness closerTruthness = calculator.computeHeuristicDocument(convertToDocument(allQuery), closer);
+        Truthness fartherTruthness = calculator.computeHeuristicDocument(convertToDocument(allQuery), farther);
+
+        assertTrue(closerTruthness.isFalse());
+        assertTrue(fartherTruthness.isFalse());
+        assertTrue(closerTruthness.getOfTrue() > fartherTruthness.getOfTrue(),
+                "a document missing fewer expected values must be scored closer to true");
+    }
+
 
     @Test
     public void testSize() {


### PR DESCRIPTION
## Problem

The truthness for `{"f": {"$all": [...]}}` is aggregated as an AND over the elements of the array held by `"f"`, each element scored by an OR over the expected values. That asks *"is every stored element one of the queried values"* — the inverse of `$all`, which requires every **queried** value to be present in the stored array and is indifferent to extra elements.

As quantifiers over the two lists:

```
MongoDB:  ∀ e ∈ expected. ∃ a ∈ actual.   a == e   ⟺  expected ⊆ actual
Current:  ∀ a ∈ actual.   ∃ e ∈ expected. a == e   ⟺  actual ⊆ expected
```

The two predicates coincide exactly when the sets are equal — which is the case the existing `testAll` covers, so the suite could not observe the difference.

## Impact

Verified by running the same six queries against a real MongoDB 7.0.40 and against the calculator:

| query vs document | MongoDB | calculator | `ofTrue` |
|---|---|---|---|
| `$all:[1,5]` vs `[1,5,6]` | match | **NO match** | 0.8200 |
| `$all:[1]` vs `[1,2,3]` | match | **NO match** | 0.6850 |
| `$all:[1,2,3]` vs `[1,2,3]` | match | match | 1.0000 |
| `$all:[1,2,3]` vs `[1,2]` | NO match | **match** | **1.0000** |
| `$all:[1,2,3]` vs `[1]` | NO match | **match** | **1.0000** |
| `$all:[1,2,3]` vs `[9]` | NO match | NO match | 0.2923 |

Four of the six disagree. The false positives report `ofTrue == 1.0`, i.e. distance 0 — a condition that no data can satisfy is recorded as already covered, so the search stops generating data for it. The false-negative direction includes the common single-value shape (`$all:[1]` against any array holding extra elements).

With this patch all six agree with MongoDB, and the gradient is monotone: `1.0000 → 0.8425 → 0.6850 → 0.2923`.

## Fix

Aggregate as an AND over the expected values, each scored by an OR over the array's elements (new `computeHeuristicForContainedValue`). The existing `$in` helper could not be reused: it holds the *actual* value fixed and ORs across the expected ones, which is the direction that caused this.

This also restores a usable gradient. Averaging over the *document's* elements meant that adding an element not in the expected list appended a low-scoring conjunct and **lowered** the score, so the search was rewarded for shrinking the array toward the expected set rather than adding the missing values — it was guided away from satisfying the condition.

`v6.1.1` had the correct direction (it summed `distanceToClosestElem(actualValues)` over the *expected* values); the quantifiers were transposed when the calculator was rewritten to return `Truthness`.

## Tests

Three tests added: one per failure direction, plus one asserting the gradient (a document missing one expected value must score strictly higher than one missing two). All three fail on current `master` and pass with the fix; the other tests are unaffected.

Full Mongo suite on this branch: **275 tests, 0 failures, 0 skipped** — `MongoHeuristicsCalculatorTest` (116), `QueryParserTest` (122), `BsonHelperTest` (21), `GeoJsonUtilsTest` (11), `GeoJsonPointTest` (3), plus the Testcontainers-backed `MongoHandlerTest` and `MongoScriptRunnerTest`.

## Out of scope

MongoDB also matches `{f: {$all: ["a"]}}` against a scalar `{f: "a"}` (confirmed on 7.0.40), whereas this code returns false for any non-array field. That is a separate defect and is left untouched here to keep the change focused on one claim.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
