### PR TITLE
Fix six MongoDB query-semantics defects in the heuristics calculator

### DIFF
--- a/client-java/controller/src/main/java/org/evomaster/client/java/controller/mongo/MongoHeuristicsCalculator.java
+++ b/client-java/controller/src/main/java/org/evomaster/client/java/controller/mongo/MongoHeuristicsCalculator.java
@@ -498,8 +498,8 @@ public class MongoHeuristicsCalculator {
     /**
      * Computes the heuristic score for the membership of a field's value in a list of expected
      * values, ie the condition shared by {"f",{"$in": [...]}} and, negated, by
-     * {"f",{"$nin": [...]}}. When the field holds an array, MongoDB checks each of its elements,
-     * and the condition holds if any of them is one of the expected values.
+     * {"f",{"$nin": [...]}}. The condition holds when the field matches any one of the expected
+     * values, in the sense of {@link #computeHeuristicForMatchedValue(Object, Object)}.
      *
      * @param fieldName      the name of the field the query is about
      * @param expectedValues the values the query lists as candidates
@@ -524,27 +524,9 @@ public class MongoHeuristicsCalculator {
             actualValue = null;
         }
 
-        if (actualValue instanceof List<?>) {
-            List<?> actualValueList = (List<?>) actualValue;
-            if (actualValueList.isEmpty()) {
-                // an empty array holds none of the expected values
-                return C_FALSE;
-            }
-            return buildOrAggregationTruthness(actualValueList.stream()
-                    .map(value -> computeHeuristic(value, expectedValues))
-                    .toArray(Truthness[]::new));
-        } else {
-            return computeHeuristic(actualValue, expectedValues);
-        }
-    }
-
-    private Truthness computeHeuristic(Object actualValue, List<?> expectedValueList) {
-        Objects.requireNonNull(expectedValueList);
-
-        Truthness res = buildOrAggregationTruthness(expectedValueList.stream()
-                .map(expectedValue -> computeHeuristicComparisonNullableValues(expectedValue, actualValue, SqlExpressionEvaluator.ComparisonOperatorType.EQUALS_TO))
+        return buildOrAggregationTruthness(expectedValues.stream()
+                .map(expectedValue -> computeHeuristicForMatchedValue(expectedValue, actualValue))
                 .toArray(Truthness[]::new));
-        return res;
     }
 
     private Truthness computeHeuristic(NotInOperation<?> operation, Object document) {
@@ -565,10 +547,11 @@ public class MongoHeuristicsCalculator {
 
     /**
      * Computes the heuristic score for a {"f",{"$all": [v1, ..., vn] }} query.
-     * The condition holds when the array held by "f" contains every one of the expected values,
-     * so the score is an AND aggregation over the expected values, each of which is scored by an
-     * OR aggregation over the elements of the array. Note the direction: extra elements in the
-     * document are irrelevant, whereas a missing expected value makes the condition false.
+     * The condition holds when "f" matches every one of the expected values, so the score is an
+     * AND aggregation over them. Note the direction: extra elements in the document are
+     * irrelevant, whereas a missing expected value makes the condition false.
+     * The field does not have to hold an array: a scalar matches a $all listing only values
+     * equal to it, which is why {"f": "a"} is matched by {"$all": ["a"]}.
      *
      * @param operation the {"f",{"$all": [...]}} query encapsulated as an AllOperation
      * @param document  the BSON document to evaluate the heuristic score against
@@ -584,40 +567,47 @@ public class MongoHeuristicsCalculator {
         } else if (expectedValues.isEmpty()) {
             return C_FALSE;
         } else {
-            Object actualValues = getValue(document, fieldName);
-            if (actualValues == null || !(actualValues instanceof List<?>)) {
-                return C_FALSE;
-            } else {
-                List<?> actualValuesList = (List<?>) actualValues;
-                if (actualValuesList.isEmpty()) {
-                    return C_FALSE;
-                } else {
-                    Truthness res = buildAndAggregationTruthness(expectedValues
-                            .stream()
-                            .map(expectedValue ->
-                                    computeHeuristicForContainedValue(expectedValue, actualValuesList))
-                            .toArray(Truthness[]::new));
-                    return buildSafeScaledTruthness(res);
-                }
-            }
+            Object actualValue = getValue(document, fieldName);
+            Truthness res = buildAndAggregationTruthness(expectedValues
+                    .stream()
+                    .map(expectedValue -> computeHeuristicForMatchedValue(expectedValue, actualValue))
+                    .toArray(Truthness[]::new));
+            return buildSafeScaledTruthness(res);
         }
     }
 
     /**
-     * Computes the heuristic score for the presence of a single expected value inside the array
-     * held by the queried field, ie an OR aggregation over the elements of that array.
+     * Computes the heuristic score for MongoDB's matching of a field against a single value,
+     * ie the condition that the field holds that value. The field matches when its own value is
+     * the expected one, and also, if it holds an array, when any element of that array is.
+     * Both readings apply at once: {"f": ["a","b"]} is matched both by the value ["a","b"] and
+     * by the value "a".
      *
-     * @param expectedValue a value that a {"f",{"$all": [...]}} query requires to be present
-     * @param actualValues  the non-empty array held by the field "f" in the document
-     * @return a Truthness object representing how close the array is to containing the expected value
+     * @param expectedValue the value the query requires the field to hold
+     * @param actualValue   the value held by the field in the document, possibly an array or null
+     * @return a Truthness object representing how close the field is to holding the expected value
      */
-    private Truthness computeHeuristicForContainedValue(Object expectedValue, List<?> actualValues) {
-        Objects.requireNonNull(actualValues);
+    private Truthness computeHeuristicForMatchedValue(Object expectedValue, Object actualValue) {
 
-        return buildOrAggregationTruthness(actualValues.stream()
-                .map(actualValue -> computeHeuristicComparisonNullableValues(expectedValue, actualValue,
-                        SqlExpressionEvaluator.ComparisonOperatorType.EQUALS_TO))
-                .toArray(Truthness[]::new));
+        Truthness wholeValue = computeHeuristicComparisonNullableValues(expectedValue, actualValue,
+                SqlExpressionEvaluator.ComparisonOperatorType.EQUALS_TO);
+
+        if (!(actualValue instanceof List<?>)) {
+            return wholeValue;
+        }
+
+        /*
+            The array as a whole is one of the options, which is also what makes an empty array
+            work: it holds no element to compare, but it can still be equal to the expected value.
+         */
+        List<?> actualValueList = (List<?>) actualValue;
+        Truthness[] options = new Truthness[actualValueList.size() + 1];
+        options[0] = wholeValue;
+        for (int i = 0; i < actualValueList.size(); i++) {
+            options[i + 1] = computeHeuristicComparisonNullableValues(expectedValue,
+                    actualValueList.get(i), SqlExpressionEvaluator.ComparisonOperatorType.EQUALS_TO);
+        }
+        return buildOrAggregationTruthness(options);
     }
 
     private static Truthness buildSafeScaledTruthness(Truthness truthness) {
@@ -969,6 +959,9 @@ public class MongoHeuristicsCalculator {
         final Truthness truthness;
         if (actualList.size() != expectedList.size()) {
             truthness = C_FALSE;
+        } else if (actualList.isEmpty()) {
+            // two empty arrays are equal, and there is no element to aggregate over
+            truthness = TRUE_C;
         } else {
             Truthness[] arrayOfTruthnesses = new Truthness[actualList.size()];
             for (int i = 0; i < actualList.size(); i++) {

--- a/client-java/controller/src/main/java/org/evomaster/client/java/controller/mongo/MongoHeuristicsCalculator.java
+++ b/client-java/controller/src/main/java/org/evomaster/client/java/controller/mongo/MongoHeuristicsCalculator.java
@@ -783,13 +783,14 @@ public class MongoHeuristicsCalculator {
     private Truthness computeHeuristic(NotOperation operation, Object document) {
         requireNonNullQueryAndDocument(operation, document);
 
-        String fieldName = operation.getFieldName();
-        if (!documentContainsField(document, fieldName)) {
-            return TRUE_C;
-        } else {
-            QueryOperation condition = operation.getCondition();
-            return computeHeuristicOnDocument(condition, document).invert();
-        }
+        /*
+            No special case for a missing field here. Several operators do match a document in
+            which the field is absent (eg $ne, $nin, and $exists with "false"), and $not must then
+            be false. The inner operators already treat an absent field as a null value, so
+            negating their score is correct whether or not the field is there.
+         */
+        QueryOperation condition = operation.getCondition();
+        return computeHeuristicOnDocument(condition, document).invert();
     }
 
     private Truthness computeHeuristic(NorOperation operation, Object document) {

--- a/client-java/controller/src/main/java/org/evomaster/client/java/controller/mongo/MongoHeuristicsCalculator.java
+++ b/client-java/controller/src/main/java/org/evomaster/client/java/controller/mongo/MongoHeuristicsCalculator.java
@@ -274,9 +274,17 @@ public class MongoHeuristicsCalculator {
             truthnessOfComparison = SqlExpressionEvaluator.calculateTruthnessForStringComparison(actualString, expectedString, comparisonOperatorType);
 
         } else {
-            // If both types are supported, but no actual comparison logic is defined,
-            // we considered them to be incompatible, therefore the comparison returns false.
-            truthnessOfComparison = C_FALSE;
+            /*
+                Both types are supported, but no comparison logic is defined for this combination,
+                ie the two values are of different, mutually incomparable BSON types.
+                MongoDB considers such values to be different from each other: an equality check is
+                then false, but an inequality check is true. Ordering comparisons do not match across
+                different BSON types either, so those stay false as well.
+             */
+            truthnessOfComparison =
+                    comparisonOperatorType == SqlExpressionEvaluator.ComparisonOperatorType.NOT_EQUALS_TO
+                            ? TRUE_C
+                            : C_FALSE;
         }
         return truthnessOfComparison;
     }

--- a/client-java/controller/src/main/java/org/evomaster/client/java/controller/mongo/MongoHeuristicsCalculator.java
+++ b/client-java/controller/src/main/java/org/evomaster/client/java/controller/mongo/MongoHeuristicsCalculator.java
@@ -335,10 +335,7 @@ public class MongoHeuristicsCalculator {
             actualValue = null;
         }
 
-        return computeHeuristicComparisonNullableValues(
-                expectedValue,
-                actualValue,
-                SqlExpressionEvaluator.ComparisonOperatorType.EQUALS_TO);
+        return computeHeuristicForMatchedValue(expectedValue, actualValue);
     }
 
     private Truthness computeHeuristicComparisonNullableValues(Object expectedValue, Object actualValue, SqlExpressionEvaluator.ComparisonOperatorType comparisonOperatorType) {
@@ -392,10 +389,7 @@ public class MongoHeuristicsCalculator {
         } else {
             actualValue = null;
         }
-        return computeHeuristicComparisonNullableValues(
-                expectedValue,
-                actualValue,
-                SqlExpressionEvaluator.ComparisonOperatorType.NOT_EQUALS_TO);
+        return computeHeuristicForMatchedValue(expectedValue, actualValue).invert();
     }
 
 

--- a/client-java/controller/src/main/java/org/evomaster/client/java/controller/mongo/MongoHeuristicsCalculator.java
+++ b/client-java/controller/src/main/java/org/evomaster/client/java/controller/mongo/MongoHeuristicsCalculator.java
@@ -492,8 +492,27 @@ public class MongoHeuristicsCalculator {
     private Truthness computeHeuristic(InOperation<?> operation, Object document) {
         requireNonNullQueryAndDocument(operation, document);
 
-        List<?> expectedValueList = operation.getValues();
-        final String fieldName = operation.getFieldName();
+        return computeHeuristicForMembership(operation.getFieldName(), operation.getValues(), document);
+    }
+
+    /**
+     * Computes the heuristic score for the membership of a field's value in a list of expected
+     * values, ie the condition shared by {"f",{"$in": [...]}} and, negated, by
+     * {"f",{"$nin": [...]}}. When the field holds an array, MongoDB checks each of its elements,
+     * and the condition holds if any of them is one of the expected values.
+     *
+     * @param fieldName      the name of the field the query is about
+     * @param expectedValues the values the query lists as candidates
+     * @param document       the BSON document to evaluate the heuristic score against
+     * @return a Truthness object representing how close the field is to holding one of the values
+     */
+    private Truthness computeHeuristicForMembership(String fieldName, List<?> expectedValues, Object document) {
+        Objects.requireNonNull(expectedValues);
+
+        if (expectedValues.isEmpty()) {
+            // no candidate value can be matched
+            return C_FALSE;
+        }
 
         final Object actualValue;
         if (documentContainsField(document, fieldName)) {
@@ -505,16 +524,18 @@ public class MongoHeuristicsCalculator {
             actualValue = null;
         }
 
-        final Truthness res;
         if (actualValue instanceof List<?>) {
             List<?> actualValueList = (List<?>) actualValue;
-            res = buildOrAggregationTruthness(actualValueList.stream()
-                    .map(value -> computeHeuristic(value, expectedValueList))
+            if (actualValueList.isEmpty()) {
+                // an empty array holds none of the expected values
+                return C_FALSE;
+            }
+            return buildOrAggregationTruthness(actualValueList.stream()
+                    .map(value -> computeHeuristic(value, expectedValues))
                     .toArray(Truthness[]::new));
         } else {
-            res = computeHeuristic(actualValue, expectedValueList);
+            return computeHeuristic(actualValue, expectedValues);
         }
-        return res;
     }
 
     private Truthness computeHeuristic(Object actualValue, List<?> expectedValueList) {
@@ -529,15 +550,17 @@ public class MongoHeuristicsCalculator {
     private Truthness computeHeuristic(NotInOperation<?> operation, Object document) {
         requireNonNullQueryAndDocument(operation, document);
 
-        List<?> expectedValues = operation.getValues();
         final String fieldName = operation.getFieldName();
 
         if (!documentContainsField(document, fieldName)) {
+            // a value that is not there cannot be one of the excluded ones
             return TRUE_C;
-        } else {
-            Object actualValue = getValue(document, fieldName);
-            return computeHeuristic(actualValue, expectedValues).invert();
         }
+        /*
+            $nin is the negation of $in, so it must consider the array elements in the same way:
+            a document whose array holds any of the excluded values does not match.
+         */
+        return computeHeuristicForMembership(fieldName, operation.getValues(), document).invert();
     }
 
     /**

--- a/client-java/controller/src/main/java/org/evomaster/client/java/controller/mongo/MongoHeuristicsCalculator.java
+++ b/client-java/controller/src/main/java/org/evomaster/client/java/controller/mongo/MongoHeuristicsCalculator.java
@@ -532,6 +532,17 @@ public class MongoHeuristicsCalculator {
         }
     }
 
+    /**
+     * Computes the heuristic score for a {"f",{"$all": [v1, ..., vn] }} query.
+     * The condition holds when the array held by "f" contains every one of the expected values,
+     * so the score is an AND aggregation over the expected values, each of which is scored by an
+     * OR aggregation over the elements of the array. Note the direction: extra elements in the
+     * document are irrelevant, whereas a missing expected value makes the condition false.
+     *
+     * @param operation the {"f",{"$all": [...]}} query encapsulated as an AllOperation
+     * @param document  the BSON document to evaluate the heuristic score against
+     * @return a Truthness object representing the distance of the document from meeting the condition
+     */
     private Truthness computeHeuristic(AllOperation<?> operation, Object document) {
         requireNonNullQueryAndDocument(operation, document);
 
@@ -550,15 +561,32 @@ public class MongoHeuristicsCalculator {
                 if (actualValuesList.isEmpty()) {
                     return C_FALSE;
                 } else {
-                    Truthness res = buildAndAggregationTruthness(actualValuesList
+                    Truthness res = buildAndAggregationTruthness(expectedValues
                             .stream()
-                            .map(actualValuesListElement ->
-                                    computeHeuristic(actualValuesListElement, expectedValues))
+                            .map(expectedValue ->
+                                    computeHeuristicForContainedValue(expectedValue, actualValuesList))
                             .toArray(Truthness[]::new));
                     return buildSafeScaledTruthness(res);
                 }
             }
         }
+    }
+
+    /**
+     * Computes the heuristic score for the presence of a single expected value inside the array
+     * held by the queried field, ie an OR aggregation over the elements of that array.
+     *
+     * @param expectedValue a value that a {"f",{"$all": [...]}} query requires to be present
+     * @param actualValues  the non-empty array held by the field "f" in the document
+     * @return a Truthness object representing how close the array is to containing the expected value
+     */
+    private Truthness computeHeuristicForContainedValue(Object expectedValue, List<?> actualValues) {
+        Objects.requireNonNull(actualValues);
+
+        return buildOrAggregationTruthness(actualValues.stream()
+                .map(actualValue -> computeHeuristicComparisonNullableValues(expectedValue, actualValue,
+                        SqlExpressionEvaluator.ComparisonOperatorType.EQUALS_TO))
+                .toArray(Truthness[]::new));
     }
 
     private static Truthness buildSafeScaledTruthness(Truthness truthness) {

--- a/client-java/controller/src/test/java/org/evomaster/client/java/controller/mongo/MongoHeuristicsCalculatorTest.java
+++ b/client-java/controller/src/test/java/org/evomaster/client/java/controller/mongo/MongoHeuristicsCalculatorTest.java
@@ -273,6 +273,40 @@ public class MongoHeuristicsCalculatorTest {
         assertTrue(calculator.computeHeuristicDocument(convertToDocument(allQuery), document).isFalse());
     }
 
+    @Test
+    public void testAllMatchesWhenDocumentArrayHasExtraElements() {
+        // $all only requires the expected values to be present; extra elements are irrelevant
+        Document doc = new Document().append("employees", new ArrayList<>(Arrays.asList(1, 5, 6)));
+        Bson allQuery = Filters.all("employees", new ArrayList<>(Arrays.asList(1, 5)));
+        MongoHeuristicsCalculator calculator = new MongoHeuristicsCalculator();
+        assertTrue(calculator.computeHeuristicDocument(convertToDocument(allQuery), doc).isTrue());
+    }
+
+    @Test
+    public void testAllDoesNotMatchWhenAnExpectedValueIsMissing() {
+        // the array contains 1, but not 2 nor 3, so the condition does not hold
+        Document doc = new Document().append("employees", new ArrayList<>(Arrays.asList(1)));
+        Bson allQuery = Filters.all("employees", new ArrayList<>(Arrays.asList(1, 2, 3)));
+        MongoHeuristicsCalculator calculator = new MongoHeuristicsCalculator();
+        assertTrue(calculator.computeHeuristicDocument(convertToDocument(allQuery), doc).isFalse());
+    }
+
+    @Test
+    public void testAllGivesBetterScoreWhenFewerExpectedValuesAreMissing() {
+        Bson allQuery = Filters.all("employees", new ArrayList<>(Arrays.asList(1, 2, 3)));
+        Document closer = new Document().append("employees", new ArrayList<>(Arrays.asList(1, 2)));
+        Document farther = new Document().append("employees", new ArrayList<>(Arrays.asList(1)));
+
+        MongoHeuristicsCalculator calculator = new MongoHeuristicsCalculator();
+        Truthness closerTruthness = calculator.computeHeuristicDocument(convertToDocument(allQuery), closer);
+        Truthness fartherTruthness = calculator.computeHeuristicDocument(convertToDocument(allQuery), farther);
+
+        assertTrue(closerTruthness.isFalse());
+        assertTrue(fartherTruthness.isFalse());
+        assertTrue(closerTruthness.getOfTrue() > fartherTruthness.getOfTrue(),
+                "a document missing fewer expected values must be scored closer to true");
+    }
+
 
     @Test
     public void testSize() {

--- a/client-java/controller/src/test/java/org/evomaster/client/java/controller/mongo/MongoHeuristicsCalculatorTest.java
+++ b/client-java/controller/src/test/java/org/evomaster/client/java/controller/mongo/MongoHeuristicsCalculatorTest.java
@@ -1186,6 +1186,35 @@ public class MongoHeuristicsCalculatorTest {
     }
 
     @Test
+    public void testEqualsMatchingAnElementOfAnArrayField() {
+        // a field holding an array matches a value when any of its elements is that value
+        Document doc = new Document().append("tags", new ArrayList<>(Arrays.asList("a", "b")));
+        MongoHeuristicsCalculator calculator = new MongoHeuristicsCalculator();
+
+        assertTrue(calculator.computeHeuristicDocument(
+                convertToDocument(Filters.eq("tags", "a")), doc).isTrue());
+        assertTrue(calculator.computeHeuristicDocument(
+                convertToDocument(Filters.ne("tags", "a")), doc).isFalse());
+
+        assertTrue(calculator.computeHeuristicDocument(
+                convertToDocument(Filters.eq("tags", "z")), doc).isFalse());
+        assertTrue(calculator.computeHeuristicDocument(
+                convertToDocument(Filters.ne("tags", "z")), doc).isTrue());
+    }
+
+    @Test
+    public void testEqualsMatchingAnArrayFieldAsAWhole() {
+        // the same field is also matched by the array itself, not only by its elements
+        Document doc = new Document().append("tags", new ArrayList<>(Arrays.asList("a", "b")));
+        MongoHeuristicsCalculator calculator = new MongoHeuristicsCalculator();
+
+        assertTrue(calculator.computeHeuristicDocument(
+                convertToDocument(Filters.eq("tags", Arrays.asList("a", "b"))), doc).isTrue());
+        assertTrue(calculator.computeHeuristicDocument(
+                convertToDocument(Filters.ne("tags", Arrays.asList("a", "b"))), doc).isFalse());
+    }
+
+    @Test
     public void testEqualsBetweenEmptyLists() {
         // two empty arrays are equal; comparing them used to have no element to aggregate over
         Document doc = new Document().append("employees", Collections.emptyList());

--- a/client-java/controller/src/test/java/org/evomaster/client/java/controller/mongo/MongoHeuristicsCalculatorTest.java
+++ b/client-java/controller/src/test/java/org/evomaster/client/java/controller/mongo/MongoHeuristicsCalculatorTest.java
@@ -315,6 +315,74 @@ public class MongoHeuristicsCalculatorTest {
     }
 
     @Test
+    public void testAllOnScalarField() {
+        // a scalar matches a $all that only lists values equal to it
+        Document doc = new Document().append("tag", "a");
+        MongoHeuristicsCalculator calculator = new MongoHeuristicsCalculator();
+
+        assertTrue(calculator.computeHeuristicDocument(
+                convertToDocument(Filters.all("tag", Arrays.asList("a"))), doc).isTrue());
+        assertTrue(calculator.computeHeuristicDocument(
+                convertToDocument(Filters.all("tag", Arrays.asList("a", "a"))), doc).isTrue());
+        assertTrue(calculator.computeHeuristicDocument(
+                convertToDocument(Filters.all("tag", Arrays.asList("a", "b"))), doc).isFalse());
+        assertTrue(calculator.computeHeuristicDocument(
+                convertToDocument(Filters.all("tag", Arrays.asList("b"))), doc).isFalse());
+    }
+
+    @Test
+    public void testAllMatchingTheArrayAsAWhole() {
+        // the expected value can be the array itself, not only one of its elements
+        Document doc = new Document().append("tags", new ArrayList<>(Arrays.asList("a", "b")));
+        Bson query = Filters.all("tags", Arrays.asList(Arrays.asList("a", "b")));
+        assertTrue(new MongoHeuristicsCalculator()
+                .computeHeuristicDocument(convertToDocument(query), doc).isTrue());
+    }
+
+    @Test
+    public void testInMatchingTheArrayAsAWhole() {
+        Document doc = new Document().append("tags", new ArrayList<>(Arrays.asList("a", "b")));
+        MongoHeuristicsCalculator calculator = new MongoHeuristicsCalculator();
+
+        Bson sameOrder = Filters.in("tags", Arrays.asList(Arrays.asList("a", "b")));
+        Bson otherOrder = Filters.in("tags", Arrays.asList(Arrays.asList("b", "a")));
+
+        // an array is equal to another one only when their elements are in the same order
+        assertTrue(calculator.computeHeuristicDocument(convertToDocument(sameOrder), doc).isTrue());
+        assertTrue(calculator.computeHeuristicDocument(convertToDocument(otherOrder), doc).isFalse());
+    }
+
+    @Test
+    public void testNotInMatchingTheArrayAsAWhole() {
+        Document doc = new Document().append("tags", new ArrayList<>(Arrays.asList("a", "b")));
+        Bson query = Filters.nin("tags", Arrays.asList(Arrays.asList("a", "b")));
+        assertTrue(new MongoHeuristicsCalculator()
+                .computeHeuristicDocument(convertToDocument(query), doc).isFalse());
+    }
+
+    @Test
+    public void testInOnEmptyArrayFieldMatchingTheEmptyArray() {
+        // the empty array holds no element, but it is still equal to the empty array
+        Document doc = new Document().append("tags", Collections.emptyList());
+        MongoHeuristicsCalculator calculator = new MongoHeuristicsCalculator();
+
+        Bson in = Filters.in("tags", Arrays.asList(Collections.emptyList()));
+        Bson nin = Filters.nin("tags", Arrays.asList(Collections.emptyList()));
+
+        assertTrue(calculator.computeHeuristicDocument(convertToDocument(in), doc).isTrue());
+        assertTrue(calculator.computeHeuristicDocument(convertToDocument(nin), doc).isFalse());
+    }
+
+    @Test
+    public void testInMatchingAnArrayElementThatIsItselfAnArray() {
+        Document doc = new Document().append("tags",
+                new ArrayList<>(Arrays.asList(Arrays.asList("a", "b"), "c")));
+        Bson query = Filters.in("tags", Arrays.asList(Arrays.asList("a", "b")));
+        assertTrue(new MongoHeuristicsCalculator()
+                .computeHeuristicDocument(convertToDocument(query), doc).isTrue());
+    }
+
+    @Test
     public void testAllMatchesWhenDocumentArrayHasExtraElements() {
         // $all only requires the expected values to be present; extra elements are irrelevant
         Document doc = new Document().append("employees", new ArrayList<>(Arrays.asList(1, 5, 6)));
@@ -1115,6 +1183,19 @@ public class MongoHeuristicsCalculatorTest {
         Truthness distanceNotMatch = new MongoHeuristicsCalculator().computeHeuristicDocument(convertToDocument(bsonFalse), doc);
         assertTrue(distanceMatch.isTrue());
         assertTrue(distanceNotMatch.isFalse());
+    }
+
+    @Test
+    public void testEqualsBetweenEmptyLists() {
+        // two empty arrays are equal; comparing them used to have no element to aggregate over
+        Document doc = new Document().append("employees", Collections.emptyList());
+        MongoHeuristicsCalculator calculator = new MongoHeuristicsCalculator();
+
+        Bson equals = Filters.eq("employees", Collections.emptyList());
+        Bson notEquals = Filters.ne("employees", Collections.emptyList());
+
+        assertTrue(calculator.computeHeuristicDocument(convertToDocument(equals), doc).isTrue());
+        assertTrue(calculator.computeHeuristicDocument(convertToDocument(notEquals), doc).isFalse());
     }
 
     @Test

--- a/client-java/controller/src/test/java/org/evomaster/client/java/controller/mongo/MongoHeuristicsCalculatorTest.java
+++ b/client-java/controller/src/test/java/org/evomaster/client/java/controller/mongo/MongoHeuristicsCalculatorTest.java
@@ -603,6 +603,40 @@ public class MongoHeuristicsCalculatorTest {
     }
 
     @Test
+    public void testNotMissingFieldWithInnerOperatorThatMatchesAbsentField() {
+        /*
+            $ne, $nin and $exists:false all match a document in which the field is absent,
+            so negating them must not match. This is the case a blanket "true when the field
+            is missing" answer gets wrong.
+         */
+        Document doc = new Document().append("name", "Bob"); // "age" field is undefined
+        MongoHeuristicsCalculator calculator = new MongoHeuristicsCalculator();
+
+        Bson notNotEquals = Filters.not(Filters.ne("age", 5));
+        Bson notNotIn = Filters.not(Filters.nin("age", new ArrayList<>(Arrays.asList(1, 2))));
+        Bson notExistsFalse = Filters.not(Filters.exists("age", false));
+
+        assertTrue(calculator.computeHeuristicDocument(convertToDocument(notNotEquals), doc).isFalse());
+        assertTrue(calculator.computeHeuristicDocument(convertToDocument(notNotIn), doc).isFalse());
+        assertTrue(calculator.computeHeuristicDocument(convertToDocument(notExistsFalse), doc).isFalse());
+    }
+
+    @Test
+    public void testNotMissingFieldWithInnerOperatorThatDoesNotMatchAbsentField() {
+        // the complementary cases, which must stay true once the missing-field shortcut is gone
+        Document doc = new Document().append("name", "Bob"); // "age" field is undefined
+        MongoHeuristicsCalculator calculator = new MongoHeuristicsCalculator();
+
+        Bson notEquals = Filters.not(Filters.eq("age", 5));
+        Bson notIn = Filters.not(Filters.in("age", new ArrayList<>(Arrays.asList(1, 2))));
+        Bson notExistsTrue = Filters.not(Filters.exists("age", true));
+
+        assertTrue(calculator.computeHeuristicDocument(convertToDocument(notEquals), doc).isTrue());
+        assertTrue(calculator.computeHeuristicDocument(convertToDocument(notIn), doc).isTrue());
+        assertTrue(calculator.computeHeuristicDocument(convertToDocument(notExistsTrue), doc).isTrue());
+    }
+
+    @Test
     public void testNotNullValue() {
         Document doc = new Document().append("age", null);
         Bson bsonTrue = Filters.not(Filters.eq("age", null));

--- a/client-java/controller/src/test/java/org/evomaster/client/java/controller/mongo/MongoHeuristicsCalculatorTest.java
+++ b/client-java/controller/src/test/java/org/evomaster/client/java/controller/mongo/MongoHeuristicsCalculatorTest.java
@@ -690,6 +690,39 @@ public class MongoHeuristicsCalculatorTest {
     }
 
     @Test
+    public void testNotEqualsStringOnIntegerField() {
+        // values of different, incomparable BSON types are different, so $ne holds
+        Document doc = new Document().append("value", 42);
+        Bson bson = Filters.ne("value", "abc");
+
+        Truthness distance = new MongoHeuristicsCalculator().computeHeuristicDocument(convertToDocument(bson), doc);
+
+        assertTrue(distance.isTrue());
+    }
+
+    @Test
+    public void testNotEqualsIntegerOnBooleanField() {
+        Document doc = new Document().append("value", true);
+        Bson bson = Filters.ne("value", 1);
+
+        Truthness distance = new MongoHeuristicsCalculator().computeHeuristicDocument(convertToDocument(bson), doc);
+
+        assertTrue(distance.isTrue());
+    }
+
+    @Test
+    public void testOrderingComparisonsStayFalseAcrossIncomparableTypes() {
+        // unlike $ne, ordering operators do not match across different BSON types
+        Document doc = new Document().append("value", 42);
+        MongoHeuristicsCalculator calculator = new MongoHeuristicsCalculator();
+
+        assertTrue(calculator.computeHeuristicDocument(convertToDocument(Filters.gt("value", "abc")), doc).isFalse());
+        assertTrue(calculator.computeHeuristicDocument(convertToDocument(Filters.gte("value", "abc")), doc).isFalse());
+        assertTrue(calculator.computeHeuristicDocument(convertToDocument(Filters.lt("value", "abc")), doc).isFalse());
+        assertTrue(calculator.computeHeuristicDocument(convertToDocument(Filters.lte("value", "abc")), doc).isFalse());
+    }
+
+    @Test
     public void testEqualsDouble() {
         Document doc = new Document().append("score", 10.5d);
         Bson bsonTrue = Filters.eq("score", 10.5d);

--- a/client-java/controller/src/test/java/org/evomaster/client/java/controller/mongo/MongoHeuristicsCalculatorTest.java
+++ b/client-java/controller/src/test/java/org/evomaster/client/java/controller/mongo/MongoHeuristicsCalculatorTest.java
@@ -220,6 +220,47 @@ public class MongoHeuristicsCalculatorTest {
     }
 
     @Test
+    public void testNotInArrayFieldHoldingAnExcludedValue() {
+        // the array holds "a", which is excluded, so the document does not match
+        Document doc = new Document().append("tags", new ArrayList<>(Arrays.asList("a", "b")));
+        Bson bson = Filters.nin("tags", new ArrayList<>(Arrays.asList("a")));
+        Truthness distance = new MongoHeuristicsCalculator().computeHeuristicDocument(convertToDocument(bson), doc);
+        assertTrue(distance.isFalse());
+    }
+
+    @Test
+    public void testNotInArrayFieldHoldingNoExcludedValue() {
+        Document doc = new Document().append("tags", new ArrayList<>(Arrays.asList("a", "b")));
+        Bson bson = Filters.nin("tags", new ArrayList<>(Arrays.asList("z")));
+        Truthness distance = new MongoHeuristicsCalculator().computeHeuristicDocument(convertToDocument(bson), doc);
+        assertTrue(distance.isTrue());
+    }
+
+    @Test
+    public void testInAndNotInOnEmptyArrayField() {
+        Document doc = new Document().append("tags", Collections.emptyList());
+        MongoHeuristicsCalculator calculator = new MongoHeuristicsCalculator();
+
+        Bson in = Filters.in("tags", new ArrayList<>(Arrays.asList("a")));
+        Bson nin = Filters.nin("tags", new ArrayList<>(Arrays.asList("a")));
+
+        assertTrue(calculator.computeHeuristicDocument(convertToDocument(in), doc).isFalse());
+        assertTrue(calculator.computeHeuristicDocument(convertToDocument(nin), doc).isTrue());
+    }
+
+    @Test
+    public void testInAndNotInOnEmptyExpectedList() {
+        Document doc = new Document().append("tags", new ArrayList<>(Arrays.asList("a", "b")));
+        MongoHeuristicsCalculator calculator = new MongoHeuristicsCalculator();
+
+        Bson in = Filters.in("tags", Collections.emptyList());
+        Bson nin = Filters.nin("tags", Collections.emptyList());
+
+        assertTrue(calculator.computeHeuristicDocument(convertToDocument(in), doc).isFalse());
+        assertTrue(calculator.computeHeuristicDocument(convertToDocument(nin), doc).isTrue());
+    }
+
+    @Test
     public void testAll() {
         Document doc = new Document().append("employees", new ArrayList<>(Arrays.asList(1, 5, 6)));
         Bson bsonTrue = Filters.all("employees", new ArrayList<>(Arrays.asList(1, 5, 6)));

--- a/core-tests/e2e-tests/spring/spring-rest-mongo/src/main/java/com/mongo/mongoqueries/MongoQueriesController.java
+++ b/core-tests/e2e-tests/spring/spring-rest-mongo/src/main/java/com/mongo/mongoqueries/MongoQueriesController.java
@@ -155,6 +155,34 @@ public class MongoQueriesController {
         return executeQuery(new Document("tags", new Document("$all", Arrays.asList("a", "b"))));
     }
 
+    /**
+     * "name" holds a string, so it is of a different, incomparable BSON type than the
+     * number being compared against. MongoDB considers such values different, so $ne holds.
+     */
+    @GetMapping("neCrossType")
+    public ResponseEntity<Void> findNeCrossType() {
+        return executeQuery(new Document("name", new Document("$ne", 42)));
+    }
+
+    /**
+     * "tags" holds an array, so $nin must look at its elements: only a document whose
+     * array does not hold "a" satisfies this.
+     */
+    @GetMapping("ninArrayField")
+    public ResponseEntity<Void> findNinArrayField() {
+        return executeQuery(new Document("tags", new Document("$nin", Arrays.asList("a"))));
+    }
+
+    /**
+     * $exists with "false" matches a document in which the field is absent, so negating it
+     * must match only the documents that do have the field.
+     */
+    @GetMapping("notExistsFalse")
+    public ResponseEntity<Void> findNotExistsFalse() {
+        return executeQuery(new Document("description",
+                new Document("$not", new Document("$exists", false))));
+    }
+
     @GetMapping("type")
     public ResponseEntity<Void> findType() {
         return executeQuery(new Document("name", new Document("$type", 2)));

--- a/core-tests/e2e-tests/spring/spring-rest-mongo/src/test/java/org/evomaster/e2etests/spring/rest/mongo/mongoqueries/MongoQueriesEMTest.java
+++ b/core-tests/e2e-tests/spring/spring-rest-mongo/src/test/java/org/evomaster/e2etests/spring/rest/mongo/mongoqueries/MongoQueriesEMTest.java
@@ -57,6 +57,9 @@ public class MongoQueriesEMTest extends RestTestBase {
                     assertHasAtLeastOne(solution, HttpVerb.GET, 200, "/mongoqueries/bitsAllSet", null);
                     assertHasAtLeastOne(solution, HttpVerb.GET, 200, "/mongoqueries/bitsAnyClear", null);
                     assertHasAtLeastOne(solution, HttpVerb.GET, 200, "/mongoqueries/all", null);
+                    assertHasAtLeastOne(solution, HttpVerb.GET, 200, "/mongoqueries/neCrossType", null);
+                    assertHasAtLeastOne(solution, HttpVerb.GET, 200, "/mongoqueries/ninArrayField", null);
+                    assertHasAtLeastOne(solution, HttpVerb.GET, 200, "/mongoqueries/notExistsFalse", null);
                     assertHasAtLeastOne(solution, HttpVerb.GET, 200, "/mongoqueries/type", null);
                     assertHasAtLeastOne(solution, HttpVerb.GET, 200, "/mongoqueries/exists", null);
                     assertHasAtLeastOne(solution, HttpVerb.GET, 200, "/mongoqueries/nor", null);


### PR DESCRIPTION
Six independent defects in `MongoHeuristicsCalculator`, each one a case where the computed truthness disagrees with what MongoDB actually does. Every claim below was checked by running the query against a real **MongoDB 7.0.40** and comparing it with the calculator, rather than reasoning from the documentation.

Supersedes #1737, which carried the `$all` fix alone. These are folded together because they touch the same class and would otherwise need rebasing against each other; each commit stands on its own if you prefer to take them separately.

| # | operator | query vs document | MongoDB | before |
|---|---|---|---|---|
| 1 | `$all` | `{tags:{$all:["a","b","c"]}}` vs `["a"]` | no match | **match, distance 0** |
| 1 | `$all` | `{tags:{$all:["a"]}}` vs `["a","b"]` | match | no match |
| 2 | `$ne` | `{age:{$ne:"abc"}}` vs `{age:20}` | match | no match, no gradient |
| 3 | `$nin` | `{tags:{$nin:["a"]}}` vs `["a","b"]` | no match | **match, distance 0** |
| 4 | `$not` | `{a:{$not:{$ne:5}}}` vs `{}` | no match | **match, distance 0** |
| 5 | `$all` | `{f:{$all:["a"]}}` vs `{f:"a"}` | match | no match |
| 5 | `$in` | `{tags:{$in:[["a","b"]]}}` vs `["a","b"]` | match | no match |
| 6 | `$eq` | `{f:{$eq:"a"}}` vs `{f:["a","b"]}` | match | no match |
| 6 | `$ne` | `{f:{$ne:"a"}}` vs `{f:["a","b"]}` | no match | match |

The rows in bold are the damaging ones: a condition that no data can satisfy is reported as already covered, so the search stops generating data for it.

## 1. `$all` was quantified in the wrong direction

The score was an AND over the elements of the array held by the field, each scored by an OR over the expected values. That asks *"is every stored element one of the queried values"*, which is the inverse of `$all`:

```
MongoDB:  ∀ e ∈ expected. ∃ a ∈ actual.   a == e   ⟺  expected ⊆ actual
Before:   ∀ a ∈ actual.   ∃ e ∈ expected. a == e   ⟺  actual ⊆ expected
```

The two coincide exactly when the sets are equal, which is the only case `testAll` covered. `v6.1.1` had the correct direction; the quantifiers were transposed when the calculator moved to `Truthness`.

Fixing the direction also restores a usable gradient. Averaging over the *document's* elements meant that adding an element not in the expected list **lowered** the score, so the search was rewarded for shrinking the array rather than adding the missing values. Measured after the fix, for `$all:[1,2,3]`: `1.0000 → 0.8425 → 0.6850 → 0.2923` as more expected values go missing.

## 2. `$ne` between incomparable BSON types

`computeHeuristicComparisonNonNullValues` fell back to `C_FALSE` whenever no comparison logic was defined for a pair of types, regardless of operator. MongoDB treats values of different, incomparable BSON types as different from each other, so `$ne` on them holds. `NOT_EQUALS_TO` now returns `TRUE_C` in that fallback.

Ordering operators were already right: `$gt`/`$gte`/`$lt`/`$lte` genuinely do not match across BSON types, which is now pinned by a test so it does not get "fixed" later.

## 3. `$nin` ignored the elements of an array-valued field

`$in` checked each element; `$nin` passed the whole array to the comparison, which has no defined comparison against a scalar, so it fell back to false and the negation turned that into a full match. Both now share `computeHeuristicForMembership` and differ only by the negation, which is the point: they are definitionally complementary.

## 4. `$not` short-circuited on a missing field

`$not` returned true whenever the field was absent. That is right only for inner operators that do not match an absent field; `$ne`, `$nin` and `$exists:false` do match one, and negating them must then be false. The generic path below the shortcut already produced the correct answer in those cases, so the shortcut was discarding a correct result.

## 5. `$all`, `$in` and `$nin` each had their own idea of what "holds a value" means

MongoDB has a single rule: a field matches a value when its own value is that value, **or**
when it holds an array of which at least one element is. Both readings apply at once, so
`{"tags": ["a","b"]}` is matched both by `["a","b"]` and by `"a"`.

Each operator implemented a different half of it:

- `$all` handled only the array reading, so any non-array field scored false, even though
  `{f:{$all:["a"]}}` matches `{f:"a"}`.
- `$in`/`$nin` handled only the element reading, so they never compared the array itself, even
  though `{tags:{$in:[["a","b"]]}}` matches `{tags:["a","b"]}`.

`computeHeuristicForMatchedValue` now implements the rule once, and the three operators are
expressed in terms of it: `$all` is an AND over the expected values, `$in` an OR, and `$nin` the
negation of `$in`. That removes the special cases for scalar and empty arrays, which the rule
covers on its own, and is a net **-11 lines**.

Order sensitivity is covered too: `["b","a"]` does not match `["a","b"]`, since arrays are equal
only element-by-element in order, while an array *holding* `["a","b"]` as an element does match.

## 6. `$eq` and `$ne` did not apply that rule either

`$eq` compared the field's value as a whole, so it missed the half of the rule that looks inside
an array. `$ne`, being its negation, had the mirrored problem. Both now go through the same
helper, so a single value means the same thing for every operator.

This also removes a live inconsistency that predates this PR: `$in` with one value already
looked at array elements while `$eq` with the same value did not, although MongoDB treats the
two identically.

The whole-array reading already worked for `$eq`, since two lists were compared element by
element; only the reading that looks inside the array was missing.

## Two latent crashes fixed along the way

Routing `$nin` through the shared membership path required guarding two cases that throw on current `master`:

```
{tags:{$in:["a"]}} against {tags: []}   -> IllegalArgumentException: null or empty Truthness instance
{tags:{$in:[]}}    against anything     -> IllegalArgumentException: null or empty Truthness instance
```

Both escape `MongoHandler.computeFindDistance`, which has no `try/catch`, and take the whole `ExtraHeuristicsDto` for that action with them. In MongoDB `$in:[]` matches nothing and `$nin:[]` matches everything, which is what the guards now produce.

A third one, older than this series and reachable from a plain `{f:{$eq:[]}}`, is fixed in the last commit: comparing two empty arrays took the branch for lists of equal size and aggregated over their zero elements, throwing the same exception instead of reporting the two as equal.

## Tests

**Unit** — 21 tests added. Full Mongo suite on this branch: **293 tests, 0 failures, 0 skipped**, including the Testcontainers-backed `MongoHandlerTest` and `MongoScriptRunnerTest`.

**E2E** — the existing endpoints exercise these operators only in shapes that were already correct: `ne` compares two numbers, `nin` is applied to a scalar field, and `not` wraps a `$gt`, which does not match an absent field. Three endpoints are added for the shapes that were broken:

| endpoint | shape |
|---|---|
| `neCrossType` | `$ne` between a string field and a number |
| `ninArrayField` | `$nin` on a field holding an array |
| `notExistsFalse` | `$not` over an operator that matches an absent field |

`ninArrayField` is deliberately not satisfied by either document that `saveData` inserts, since both hold `"a"`, so it can only be covered by data EvoMaster generates itself. `$all` already has an endpoint and needed none.

## Notes

`MongoHeuristicsCalculator` goes from 934 to **987 lines**, ie just under the 1000-line guideline in `for_developers.md`. Worth flagging given how quickly this class is growing.

Point 6 is a behavioural change to the most widely used operator, since the implicit form
`{f: "a"}` parses to the same operation, so it is worth a closer look than the rest. It is the
last commit and can be dropped on its own if you would rather take it separately.