### PR TITLE
Send target ids in the request body when fetching coverage, to avoid 414

### DIFF
--- a/client-java/controller/src/main/java/org/evomaster/client/java/controller/internal/EMController.java
+++ b/client-java/controller/src/main/java/org/evomaster/client/java/controller/internal/EMController.java
@@ -450,6 +450,21 @@ public class EMController {
     }
 
 
+    /**
+     * Return the coverage of the test executed so far, plus the extra heuristics.
+     *
+     * <p>
+     * This is kept as the compatibility form of the endpoint. EvoMaster Core no longer calls it:
+     * it uses the POST variant below, because the ids of the targets do not always fit in a URI.
+     * It is still part of the public contract of the Driver, though, and is what any Core older
+     * than this change talks to. It is also the only form usable by hand, eg with curl, to inspect
+     * a running Driver.
+     * </p>
+     *
+     * <p>
+     * Both forms share the exact same logic: see {@link #computeTestResults}.
+     * </p>
+     */
     @Path(ControllerConstants.TEST_RESULTS)
     @GET
     public Response getTestResults(
@@ -458,6 +473,9 @@ public class EMController {
              * If none specified, return everything.
              * If a target was seen for first time, it is returned even if
              * not asked for.
+             *
+             * Note: on a large search there can be thousands of them, and they would not fit
+             * in the URI. Use the POST variant of this endpoint in that case.
              */
             @QueryParam("ids")
             @DefaultValue("")
@@ -479,29 +497,89 @@ public class EMController {
             boolean queryFromDatabase,
             @Context HttpServletRequest httpServletRequest) {
 
+        prepareForTestResults(httpServletRequest);
+
+        Set<Integer> ids;
+        if(idList != null && !idList.isEmpty()) {
+            try {
+                ids = Arrays.stream(idList.split(","))
+                        .filter(s -> !s.trim().isEmpty())
+                        .map(Integer::parseInt)
+                        .collect(Collectors.toSet());
+            } catch (NumberFormatException e) {
+                String msg = "Invalid parameter 'ids': " + e.getMessage();
+                SimpleLogger.warn(msg);
+                return Response.status(400).entity(WrappedResponseDto.withError(msg)).build();
+            }
+        } else {
+            ids = null;
+        }
+
+        return computeTestResults(ids, killSwitch, fullyCovered, descriptiveIds, queryFromDatabase);
+    }
+
+    /**
+     * Same as the GET variant, but with the ids of the targets in the body payload instead of
+     * in the URI. This is the form EvoMaster Core uses.
+     *
+     * <p>
+     * A search can easily end up asking for thousands of targets at once. Their ids do not fit
+     * in the request line: Jetty rejects with a 414 anything above 8192 bytes, well before the
+     * request reaches this class. Sending them in the body has no such limit.
+     * </p>
+     *
+     * <p>
+     * A POST for what is a read is not great REST, but there is no alternative: a GET carrying a
+     * body cannot be sent by the HTTP client in use (the JDK rewrites the method to POST on its
+     * own as soon as anything is written to the connection).
+     * </p>
+     *
+     * @param idList the ids of the targets to return fitness score for. As in the GET variant,
+     *               an empty (or missing) list means "return everything".
+     */
+    @Path(ControllerConstants.TEST_RESULTS)
+    @POST
+    @Consumes(MediaType.APPLICATION_JSON)
+    public Response getTestResultsWithIdsInBody(
+            List<Integer> idList,
+            @QueryParam("killSwitch") @DefaultValue("false")
+            boolean killSwitch,
+            @QueryParam("fullyCovered") @DefaultValue("false")
+            boolean fullyCovered,
+            @QueryParam("descriptiveIds") @DefaultValue("false")
+            boolean descriptiveIds,
+            @QueryParam("queryFromDatabase") @DefaultValue("true")
+            boolean queryFromDatabase,
+            @Context HttpServletRequest httpServletRequest) {
+
+        prepareForTestResults(httpServletRequest);
+
+        /*
+            An empty list must mean "all targets", exactly like an empty 'ids' query parameter
+            does in the GET variant. Passing an empty set here instead of null would silently
+            return no target at all.
+         */
+        Set<Integer> ids = (idList == null || idList.isEmpty()) ? null : new HashSet<>(idList);
+
+        return computeTestResults(ids, killSwitch, fullyCovered, descriptiveIds, queryFromDatabase);
+    }
+
+    private void prepareForTestResults(HttpServletRequest httpServletRequest) {
 
         // notify that actions execution is done.
         noKillSwitch(() -> sutController.setExecutingAction(false));
 
         assert trackRequestSource(httpServletRequest);
+    }
+
+    private Response computeTestResults(
+            Set<Integer> ids,
+            boolean killSwitch,
+            boolean fullyCovered,
+            boolean descriptiveIds,
+            boolean queryFromDatabase) {
 
         try {
-            Set<Integer> ids;
-            if(idList != null && !idList.isEmpty()) {
-                try {
-                    ids = Arrays.stream(idList.split(","))
-                            .filter(s -> !s.trim().isEmpty())
-                            .map(Integer::parseInt)
-                            .collect(Collectors.toSet());
-                } catch (NumberFormatException e) {
-                    String msg = "Invalid parameter 'ids': " + e.getMessage();
-                    SimpleLogger.warn(msg);
-                    return Response.status(400).entity(WrappedResponseDto.withError(msg)).build();
-                }
-            } else {
-                ids = null;
-            }
-
             List<TargetInfo> targetInfos = noKillSwitch(() -> sutController.getTargetInfos(ids, fullyCovered, descriptiveIds));
             if (targetInfos == null) {
                 String label = "all";

--- a/client-java/controller/src/test/java/org/evomaster/client/java/controller/internal/db/sql/HeuristicsCalculatorInDBTest.java
+++ b/client-java/controller/src/test/java/org/evomaster/client/java/controller/internal/db/sql/HeuristicsCalculatorInDBTest.java
@@ -35,7 +35,9 @@ public interface HeuristicsCalculatorInDBTest extends DatabaseTestTemplate {
             EMSqlScriptRunner.execCommand(getConnection(), "INSERT INTO Foo (x) VALUES (10)", false);
 
             given().accept(ContentType.JSON)
-                    .get(url + TEST_RESULTS)
+                    .contentType(ContentType.JSON)
+                    .body("[]")
+                    .post(url + TEST_RESULTS)
                     .then()
                     .statusCode(200)
                     .body("data.extraHeuristics.size()", is(1))
@@ -49,7 +51,9 @@ public interface HeuristicsCalculatorInDBTest extends DatabaseTestTemplate {
             EMSqlScriptRunner.execCommand(getConnection(), "SELECT x FROM Foo WHERE x = 10", true);
 
             RestAssured.given().accept(ContentType.JSON)
-                    .get(url + ControllerConstants.TEST_RESULTS)
+                    .contentType(ContentType.JSON)
+                    .body("[]")
+                    .post(url + ControllerConstants.TEST_RESULTS)
                     .then()
                     .statusCode(200)
                     .body("data.extraHeuristics.size()", Matchers.is(1))
@@ -62,7 +66,9 @@ public interface HeuristicsCalculatorInDBTest extends DatabaseTestTemplate {
             EMSqlScriptRunner.execCommand(getConnection(), "SELECT x FROM Foo WHERE x = 13", true);
 
             RestAssured.given().accept(ContentType.JSON)
-                    .get(url + ControllerConstants.TEST_RESULTS)
+                    .contentType(ContentType.JSON)
+                    .body("[]")
+                    .post(url + ControllerConstants.TEST_RESULTS)
                     .then()
                     .statusCode(200)
                     .body("data.extraHeuristics.size()", Matchers.is(2))
@@ -212,7 +218,9 @@ public interface HeuristicsCalculatorInDBTest extends DatabaseTestTemplate {
     default Double getFirstAndStartNew(String url) {
 
         double value = Double.parseDouble(RestAssured.given().accept(ContentType.JSON)
-                .get(url + ControllerConstants.TEST_RESULTS)
+                .contentType(ContentType.JSON)
+                .body("[]")
+                .post(url + ControllerConstants.TEST_RESULTS)
                 .then()
                 .statusCode(200)
                 .extract().body().path("data.extraHeuristics[0].heuristics[0].value").toString());

--- a/client-java/controller/src/test/java/org/evomaster/client/java/controller/internal/db/sql/HeuristicsCalculatorWithSqlInsertionTest.java
+++ b/client-java/controller/src/test/java/org/evomaster/client/java/controller/internal/db/sql/HeuristicsCalculatorWithSqlInsertionTest.java
@@ -43,7 +43,9 @@ public interface HeuristicsCalculatorWithSqlInsertionTest extends DatabaseTestTe
 //            EMSqlScriptRunner.execCommand(getConnection(), "INSERT INTO Foo (x) VALUES (10)", false);
 
             given().accept(ContentType.JSON)
-                    .get(url + TEST_RESULTS + "?queryFromDatabase=false")
+                    .contentType(ContentType.JSON)
+                    .body("[]")
+                    .post(url + TEST_RESULTS + "?queryFromDatabase=false")
                     .then()
                     .statusCode(200)
                     .body("data.extraHeuristics.size()", is(1))
@@ -58,7 +60,9 @@ public interface HeuristicsCalculatorWithSqlInsertionTest extends DatabaseTestTe
             EMSqlScriptRunner.execCommand(getConnection(), "SELECT x FROM Foo WHERE x = 10", true);
 
             RestAssured.given().accept(ContentType.JSON)
-                    .get(url + ControllerConstants.TEST_RESULTS + "?queryFromDatabase=false")
+                    .contentType(ContentType.JSON)
+                    .body("[]")
+                    .post(url + ControllerConstants.TEST_RESULTS + "?queryFromDatabase=false")
                     .then()
                     .statusCode(200)
                     .body("data.extraHeuristics.size()", Matchers.is(1))
@@ -71,7 +75,9 @@ public interface HeuristicsCalculatorWithSqlInsertionTest extends DatabaseTestTe
             EMSqlScriptRunner.execCommand(getConnection(), "SELECT x FROM Foo WHERE x = 13", true);
 
             RestAssured.given().accept(ContentType.JSON)
-                    .get(url + ControllerConstants.TEST_RESULTS + "?queryFromDatabase=false")
+                    .contentType(ContentType.JSON)
+                    .body("[]")
+                    .post(url + ControllerConstants.TEST_RESULTS + "?queryFromDatabase=false")
                     .then()
                     .statusCode(200)
                     .body("data.extraHeuristics.size()", Matchers.is(2))
@@ -299,7 +305,9 @@ public interface HeuristicsCalculatorWithSqlInsertionTest extends DatabaseTestTe
     default Double getFirstAndStartNew(String url) {
 
         double value = Double.parseDouble(RestAssured.given().accept(ContentType.JSON)
-                .get(url + ControllerConstants.TEST_RESULTS + "?queryFromDatabase=false")
+                .contentType(ContentType.JSON)
+                .body("[]")
+                .post(url + ControllerConstants.TEST_RESULTS + "?queryFromDatabase=false")
                 .then()
                 .statusCode(200)
                 .extract().body().path("data.extraHeuristics[0].heuristics[0].value").toString());

--- a/client-java/controller/src/test/java/org/evomaster/client/java/controller/internal/db/sql/InitSqlScriptWithSmartDbCleanTest.java
+++ b/client-java/controller/src/test/java/org/evomaster/client/java/controller/internal/db/sql/InitSqlScriptWithSmartDbCleanTest.java
@@ -82,7 +82,9 @@ public interface InitSqlScriptWithSmartDbCleanTest extends DatabaseTestTemplate 
             assertEquals(2, res.seeRows().size());
 
             RestAssured.given().accept(ContentType.JSON)
-                    .get(url + ControllerConstants.TEST_RESULTS)
+                    .contentType(ContentType.JSON)
+                    .body("[]")
+                    .post(url + ControllerConstants.TEST_RESULTS)
                     .then()
                     .statusCode(200);
 
@@ -118,7 +120,9 @@ public interface InitSqlScriptWithSmartDbCleanTest extends DatabaseTestTemplate 
 
 
             RestAssured.given().accept(ContentType.JSON)
-                    .get(url + ControllerConstants.TEST_RESULTS)
+                    .contentType(ContentType.JSON)
+                    .body("[]")
+                    .post(url + ControllerConstants.TEST_RESULTS)
                     .then()
                     .statusCode(200);
 
@@ -157,7 +161,9 @@ public interface InitSqlScriptWithSmartDbCleanTest extends DatabaseTestTemplate 
 
 
             RestAssured.given().accept(ContentType.JSON)
-                .get(url + ControllerConstants.TEST_RESULTS)
+                .contentType(ContentType.JSON)
+                .body("[]")
+                .post(url + ControllerConstants.TEST_RESULTS)
                 .then()
                 .statusCode(200);
 

--- a/client-java/controller/src/test/java/org/evomaster/client/java/controller/internal/db/sql/SmartDbCleanTest.java
+++ b/client-java/controller/src/test/java/org/evomaster/client/java/controller/internal/db/sql/SmartDbCleanTest.java
@@ -40,7 +40,9 @@ public interface SmartDbCleanTest extends DatabaseTestTemplate {
             assertEquals(1, res.seeRows().size());
 
             RestAssured.given().accept(ContentType.JSON)
-                    .get(url + ControllerConstants.TEST_RESULTS)
+                    .contentType(ContentType.JSON)
+                    .body("[]")
+                    .post(url + ControllerConstants.TEST_RESULTS)
                     .then()
                     .statusCode(200);
 
@@ -55,7 +57,9 @@ public interface SmartDbCleanTest extends DatabaseTestTemplate {
             assertEquals(1, res.seeRows().size());
 
             RestAssured.given().accept(ContentType.JSON)
-                    .get(url + ControllerConstants.TEST_RESULTS)
+                    .contentType(ContentType.JSON)
+                    .body("[]")
+                    .post(url + ControllerConstants.TEST_RESULTS)
                     .then()
                     .statusCode(200);
 
@@ -107,7 +111,9 @@ public interface SmartDbCleanTest extends DatabaseTestTemplate {
             assertEquals(1, res.seeRows().size());
 
             RestAssured.given().accept(ContentType.JSON)
-                    .get(url + ControllerConstants.TEST_RESULTS)
+                    .contentType(ContentType.JSON)
+                    .body("[]")
+                    .post(url + ControllerConstants.TEST_RESULTS)
                     .then()
                     .statusCode(200);
 
@@ -128,7 +134,9 @@ public interface SmartDbCleanTest extends DatabaseTestTemplate {
             assertEquals(1, res.seeRows().size());
 
             RestAssured.given().accept(ContentType.JSON)
-                    .get(url + ControllerConstants.TEST_RESULTS)
+                    .contentType(ContentType.JSON)
+                    .body("[]")
+                    .post(url + ControllerConstants.TEST_RESULTS)
                     .then()
                     .statusCode(200);
 
@@ -181,7 +189,9 @@ public interface SmartDbCleanTest extends DatabaseTestTemplate {
             assertEquals(1, res.seeRows().size());
 
             RestAssured.given().accept(ContentType.JSON)
-                    .get(url + ControllerConstants.TEST_RESULTS)
+                    .contentType(ContentType.JSON)
+                    .body("[]")
+                    .post(url + ControllerConstants.TEST_RESULTS)
                     .then()
                     .statusCode(200);
 
@@ -200,7 +210,9 @@ public interface SmartDbCleanTest extends DatabaseTestTemplate {
             assertEquals(1, res.seeRows().size());
 
             RestAssured.given().accept(ContentType.JSON)
-                    .get(url + ControllerConstants.TEST_RESULTS)
+                    .contentType(ContentType.JSON)
+                    .body("[]")
+                    .post(url + ControllerConstants.TEST_RESULTS)
                     .then()
                     .statusCode(200);
 

--- a/client-java/controller/src/test/java/org/evomaster/client/java/controller/internal/db/sql/SqlHandlerInDBTest.java
+++ b/client-java/controller/src/test/java/org/evomaster/client/java/controller/internal/db/sql/SqlHandlerInDBTest.java
@@ -27,7 +27,9 @@ public interface SqlHandlerInDBTest extends DatabaseTestTemplate {
     default SqlExecutionsDto getSqlExecutionDto(int index, String url) {
 
         TestResultsDto dto = RestAssured.given().accept(ContentType.JSON)
-                .get(url + ControllerConstants.TEST_RESULTS)
+                .contentType(ContentType.JSON)
+                .body("[]")
+                .post(url + ControllerConstants.TEST_RESULTS)
                 .then()
                 .statusCode(200)
                 .extract().body().jsonPath()

--- a/core/src/main/kotlin/org/evomaster/core/remote/service/RemoteControllerImplementation.kt
+++ b/core/src/main/kotlin/org/evomaster/core/remote/service/RemoteControllerImplementation.kt
@@ -328,20 +328,23 @@ class RemoteControllerImplementation() : RemoteController{
         descriptiveIds: Boolean
     ): TestResultsDto? {
 
-        val queryParam = ids.joinToString(",")
-
         if(epc?.isInSearch() == true) stc?.averageOverheadMsTestResultsSubset?.doStartTimer()
 
+        /*
+            The ids go in the body payload, and not as a query parameter, because there can be
+            thousands of them. Sent in the URI they would not fit in the request line, and the
+            driver would answer 414 before even receiving the request.
+            Note: an empty list means "all targets", and the driver treats it as such.
+         */
         val response = makeHttpCall {
             getWebTarget()
                     .path(ControllerConstants.TEST_RESULTS)
-                    .queryParam("ids", queryParam)
                     .queryParam("killSwitch", !ignoreKillSwitch && config.killSwitch)
                     .queryParam("fullyCovered", fullyCovered)
                     .queryParam("descriptiveIds", descriptiveIds)
                     .queryParam("queryFromDatabase", !config.useInsertionForSqlHeuristics)
                     .request(MediaType.APPLICATION_JSON_TYPE)
-                    .get()
+                    .post(Entity.entity(ids, MediaType.APPLICATION_JSON_TYPE))
         }
         if(epc?.isInSearch() == true) stc?.averageOverheadMsTestResultsSubset?.addElapsedTime()
 
@@ -360,7 +363,7 @@ class RemoteControllerImplementation() : RemoteController{
 
         val dto = getDtoFromResponse(response, object : GenericType<WrappedResponseDto<TestResultsDto>>() {})
 
-        if(!checkResponse(response, dto, "Failed to retrieve target coverage for $queryParam")){
+        if(!checkResponse(response, dto, "Failed to retrieve target coverage for ${ids.size} ids")){
             return null
         }
 

--- a/core/src/test/kotlin/org/evomaster/core/remote/service/RemoteControllerManyTargetsTest.kt
+++ b/core/src/test/kotlin/org/evomaster/core/remote/service/RemoteControllerManyTargetsTest.kt
@@ -1,0 +1,189 @@
+package org.evomaster.core.remote.service
+
+import org.evomaster.client.java.controller.EmbeddedSutController
+import org.evomaster.client.java.controller.api.dto.ActionDto
+import org.evomaster.client.java.controller.api.dto.SutInfoDto
+import org.evomaster.client.java.controller.api.dto.auth.AuthenticationDto
+import org.evomaster.client.java.controller.problem.ProblemInfo
+import org.evomaster.client.java.controller.problem.RestProblem
+import org.evomaster.client.java.instrumentation.staticstate.ExecutionTracer
+import org.evomaster.client.java.instrumentation.staticstate.ObjectiveRecorder
+import org.evomaster.client.java.sql.DbSpecification
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+/**
+ * Asking the driver for the coverage of a large set of targets fails, because the ids are sent
+ * as a query parameter and the resulting URI does not fit in the request line.
+ *
+ * Measured on the "jasper" case study (120s, seed 1): during the recomputation stage of the
+ * minimization, [org.evomaster.core.problem.enterprise.service.EnterpriseFitness] refetches
+ * descriptive ids for 1554 targets. That is 7302 characters of query string, which together with
+ * the path, the other query parameters and the standard headers goes over the 8192 bytes that
+ * Jetty allows by default for a request. Jetty answers 414 before the request ever reaches
+ * [org.evomaster.client.java.controller.internal.EMController], so the driver code never runs and
+ * cannot do anything about it.
+ *
+ * On the EvoMaster side the 414 is not an exception: [RemoteControllerImplementation.getTestResults]
+ * just returns null, the caller logs "Cannot retrieve coverage with full descriptive ids", and the
+ * individual is dropped. 22 individuals were lost this way in a single jasper run.
+ *
+ * The test drives the real client ([RemoteControllerImplementation]) against a real driver, on
+ * purpose: it asserts on the outcome of the API call, not on how the ids happen to be transported.
+ * That way it keeps passing unchanged once the transport is moved off the URI, and it would catch
+ * a regression if it ever moved back.
+ */
+class RemoteControllerManyTargetsTest {
+
+    companion object {
+
+        /**
+         * Number of targets refetched in the jasper run that exposed the problem.
+         */
+        const val NUMBER_OF_TARGETS = 1554
+
+        /**
+         * Realistic magnitude for target ids at the end of a run. Jasper had registered more than
+         * 10000 targets by the time minimization started, so the ids being refetched were 5 digits
+         * long. Starting from 0 would make the query string shorter than what a real search
+         * produces, and the test weaker.
+         */
+        const val FIRST_ID = 10_000
+
+        const val FAKE_SWAGGER = "/swagger.json"
+    }
+
+    private class FakeRestController : EmbeddedSutController() {
+
+        var running: Boolean = false
+
+        override fun startSut(): String? {
+            running = true
+            return null
+        }
+
+        override fun isSutRunning(): Boolean = running
+
+        override fun stopSut() {
+            running = false
+        }
+
+        override fun getPackagePrefixesToCover(): String? = null
+
+        override fun resetStateOfSUT() {}
+
+        override fun getInfoForAuthentication(): List<AuthenticationDto>? = null
+
+        override fun getDbSpecifications(): MutableList<DbSpecification>? = null
+
+        override fun getProblemInfo(): ProblemInfo = RestProblem(FAKE_SWAGGER, null)
+
+        override fun getPreferredOutputFormat(): SutInfoDto.OutputFormat =
+            SutInfoDto.OutputFormat.JAVA_JUNIT_5
+    }
+
+    private val driver = FakeRestController()
+    private lateinit var remote: RemoteController
+
+    @BeforeEach
+    fun init() {
+        if (driver.isSutRunning) {
+            driver.stopSut()
+        }
+        driver.controllerPort = 0 //ephemeral
+        driver.startTheControllerServer()
+
+        remote = RemoteControllerImplementation("localhost", driver.controllerServerPort, false, false)
+    }
+
+    @AfterEach
+    fun tearDown() {
+        driver.stopSut()
+        remote.close()
+        driver.stopTheControllerServer()
+    }
+
+
+    @Test
+    fun testGetTestResultsForManyTargets() {
+
+        remote.startANewSearch()
+        remote.startSUT()
+        remote.registerNewAction(ActionDto().apply { index = 0 })
+
+        /*
+            The driver refuses to report on an id it never handed out ("Id 'x' is not mapped"),
+            so first let it map as many targets as an instrumented SUT would. This is the same
+            call the instrumentation makes the first time it sees a target, and it assigns the
+            numeric ids sequentially from 0.
+         */
+        repeat(FIRST_ID + NUMBER_OF_TARGETS) { i ->
+            ObjectiveRecorder.getMappedId("Branch_at_Foo_at_line_$i")
+        }
+
+        /*
+            Control: the very same call, with few ids, works. None of these targets was ever
+            covered, so the driver answers with a "not reached" entry for each requested id.
+            The only thing that changes below is how many ids are asked for.
+         */
+        val few = (FIRST_ID until FIRST_ID + 10).toSet()
+        val small = remote.getTestResults(ids = few, descriptiveIds = true)
+        assertNotNull(small, "Baseline call with ${few.size} ids should work")
+        assertEquals(few.size, small!!.targets.size)
+
+        val many = (FIRST_ID until FIRST_ID + NUMBER_OF_TARGETS).toSet()
+
+        val results = remote.getTestResults(ids = many, descriptiveIds = true)
+
+        assertNotNull(results,
+            "Failed to fetch the coverage of ${many.size} targets." +
+                    " Sent as a query parameter, their ids alone take" +
+                    " ${many.joinToString(",").length} characters," +
+                    " which does not fit in the ${8 * 1024} bytes Jetty allows for a request.")
+        assertEquals(many.size, results!!.targets.size)
+    }
+
+    /**
+     * Asking for no id at all means "every target".
+     *
+     * This is easy to break while changing how the ids are transported. An empty list arriving
+     * at the driver has to be turned back into null, which is what
+     * [org.evomaster.client.java.instrumentation.InstrumentationController.getTargetInfos] reads
+     * as "send everything". Passing an empty set instead would answer 200 with an empty, perfectly
+     * well formed coverage: no error anywhere, and a search that silently sees nothing.
+     */
+    @Test
+    fun testGetTestResultsForAllTargets() {
+
+        remote.startANewSearch()
+        remote.startSUT()
+        remote.registerNewAction(ActionDto().apply { index = 0 })
+
+        //cover some real targets, so that "everything" and "nothing" are distinguishable
+        val comparisons = 5
+        repeat(comparisons) { i ->
+            ExecutionTracer.executedNumericComparison("Foo_at_line_$i", 0.1, 0.2, 1.0)
+        }
+
+        /*
+            Targets seen for the first time are sent back whether they were asked for or not, so
+            while that list is populated an empty request looks the same as a correct one. The
+            driver empties it at the start of every new test, and that is precisely the state
+            during the recomputation stage of the minimization, which only re-runs tests whose
+            targets are all already known.
+         */
+        ObjectiveRecorder.clearFirstTimeEncountered()
+
+        val all = remote.getTestResults()
+
+        assertNotNull(all, "Failed to fetch the coverage of all targets")
+        assertTrue(all!!.targets.isNotEmpty(),
+            "Asking with no id returned no target at all." +
+                    " An empty list of ids must be understood as a request for every target.")
+        assertEquals(comparisons * 3, all.targets.size)
+    }
+}


### PR DESCRIPTION
## Problem

`RemoteControllerImplementation.getTestResults` sent the ids of the targets as an `ids`
query parameter. On a large search there are thousands of them, and the resulting URI does
not fit in the request line: Jetty rejects anything above 8192 bytes with a **414**, before
the request ever reaches `EMController`, so the driver code never runs and cannot do
anything about it.

Measured on the `jasper` case study (120s, seed 1): during the recomputation stage of the
minimization, `EnterpriseFitness` refetches descriptive ids for **1554 targets**, which is
**7302 characters** of query string. Together with the path, the other query parameters and
the standard headers, that is over the limit.

On the EvoMaster side the 414 is not an exception. `getTestResults` returns `null`, the
caller logs `Cannot retrieve coverage with full descriptive ids`, and the **individual is
dropped along with all of its targets**. 22 individuals were lost this way in a single
jasper run. The failure is silent: nothing in the output says that coverage was thrown away.

## Change

- `EMController` gains a **`POST`** variant of `testResults` that takes the ids in the body.
  Both variants delegate to the same private `computeTestResults`, so there is exactly one
  implementation of the logic.
- An empty (or missing) id list keeps meaning **"all targets"** in the POST variant, as it
  already does for the empty `ids` query parameter. Passing an empty set instead of `null`
  would silently return no target at all.
- `RemoteControllerImplementation` now uses the POST variant.
- The `GET` variant is kept. It is part of the public contract of the Driver, it is what any
  Core older than this change talks to, and it is the only form usable by hand (eg with
  `curl`) to inspect a running Driver.

A `POST` for what is a read is not great REST, but there is no alternative: a `GET` carrying
a body cannot be sent by the HTTP client in use, as the JDK rewrites the method to `POST` on
its own as soon as anything is written to the connection.

## Test

`RemoteControllerManyTargetsTest` drives the real client against a real driver and asks for
the 1554 targets that exposed the problem, with ids of realistic magnitude (5 digits, as at
the end of a jasper run). It asserts on the outcome of the API call rather than on how the
ids happen to be transported, so it keeps passing unchanged if the transport moves again,
and it catches a regression if it ever moves back into the URI.

## Compatibility

A Core with this change **requires a Driver with this change**: there is no fallback to the
`GET` variant if the `POST` is not there. The opposite direction is fine, since the `GET` is
still served. Anything that pins the client version needs to be updated together with the
Core — in EMB, `evomaster-version` in `jdk_25_maven/pom.xml`.

## Effect

Measured on `jasper`, 300s, 12 successful runs over seeds 1-9, 6 per configuration.
`--heuristicsForSQLAdvanced=true` was needed in all of them to work around an unrelated
pre-existing problem with table functions in this SUT.

| | before this change | with this change |
|---|---|---|
| HTTP 414 | present | 0 in 12 runs |
| `Cannot retrieve coverage` | 12 per run | 0 in 12 runs |
| SUT restarts | 6 per run | 0 in 12 runs |
| targets lost in the recompute (`--minimizeThresholdForLoss=0`) | 465 | **0 in 6 of 6** |

With the loss threshold at 0 the warning fires if a single target is lost, so this is a
categorical result rather than an average.

Minimization now behaves as it should: comparing `--minimize=true` against `--minimize=false`
gives **+343 targets (+3.0%, Â12 = 0.833)** and **29 fewer generated tests (-6.1%)**. Before,
the reported number went *down* by 425 when minimizing.

## GET vs POST

The obvious alternative is to keep the `GET` and move the ids into its body. EvoMaster
already does exactly that elsewhere: `AbstractRestFitness` builds
`builder.build("GET", bodyEntity)` for `GET` and `DELETE` (`AbstractRestFitness.kt:1132-1133`),
citing RFC 9110 §9.3.1. That works because those calls go through the client from
`HttpClientFactory.createTrustingJerseyClient()`, which configures `ApacheConnectorProvider`
(`HttpClientFactory.kt:62`) precisely for this — its comment says the Jersey default "does not
handle PATCH properly and body payloads in GET/DELETE" — and disables JAX-RS compliance
validation (`HttpClientFactory.kt:74`).

The problem is that this endpoint is not that connection. Calls to the SUT are made with the
Apache-backed client; the Core-to-Driver connection uses `ClientBuilder.newClient()`
(`RemoteControllerImplementation.kt:61`), ie Jersey's default `HttpUrlConnector` over
`java.net.HttpURLConnection`, which silently rewrites the method to `POST` as soon as anything
is written to the connection.

Switching this client to the Apache connector would make a `GET` with a body technically
possible, but it would make the protocol depend on which connector is actually active at
runtime — and per the comment in `HttpClientFactory.kt:80-88`, that is not something we can
rely on or even check:

> using Jersey is a shitshow... based on classpath misconfiguration, can pick up wrong provider
> regardless of what you specify here, doing it silently
>
> check passes on IDE, but then fail in Maven when using shaded client in the E2E

The assertion that would verify the connector is commented out for that reason. So if the
connector silently degrades, the `GET` becomes a `POST` against an endpoint that would not
exist, or fails compliance validation — and it breaks every coverage request of every run,
not just a few SUT calls.

Two further reasons not to take that route:

- **Silent version skew.** An older Driver's `@GET` has only `@QueryParam`s and never reads a
  body, so `ids` would default to empty, which that endpoint documents as "return everything".
  A Core sending the ids in a `GET` body against an older Driver would silently get *all*
  targets instead of the requested subset. With `POST` the same mismatch is an immediate 405.
- **The endpoint is a public contract of the Driver**, also implemented by the JavaScript and
  .NET drivers. `POST` with a JSON body is supported out of the box by every server framework;
  reading a body on `GET` is not.